### PR TITLE
feat(#189): standard explicit empty-state component across detail pages

### DIFF
--- a/app/static/css/components/empty-states.css
+++ b/app/static/css/components/empty-states.css
@@ -33,6 +33,51 @@
 }
 
 /* ==========================================================================
+   Standard explicit empty state (#189)
+   ----------------------------------------------------------------------------
+   One consistent vocabulary for "data is missing here" across detail pages.
+   Used via the data_empty() / field_empty() macros in components/_macros.html.
+
+   Two tiers:
+     .data-empty  — section/block level: "No <X> on record" + optional hint.
+                    Reads as intentionally-empty, not broken.
+     .field-empty — inline field level: an em dash or short "No data" marker
+                    sitting where a value would be.
+
+   Both are real text (not a visual-only cue) so screen readers announce them.
+   ========================================================================== */
+
+.data-empty {
+    padding: var(--space-8) var(--space-6);
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+    border: var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-raised);
+}
+
+.data-empty__title {
+    margin: 0;
+    color: var(--color-text);
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+}
+
+.data-empty__hint {
+    margin: var(--space-2) 0 0;
+    color: var(--color-text-subtle);
+    font-size: var(--text-xs);
+    line-height: var(--line-height-relaxed);
+}
+
+/* Inline field-level marker — italic + subtle, sits in the value slot. */
+.field-empty {
+    font-style: italic;
+    color: var(--color-text-subtle);
+}
+
+/* ==========================================================================
    Contribute Buttons
    ========================================================================== */
 

--- a/app/static/css/pages/scholars.css
+++ b/app/static/css/pages/scholars.css
@@ -362,16 +362,8 @@ main.scholar-detail {
     border-color: var(--color-badge-blue-border);
 }
 
-/* Empty state */
-.scholar-empty {
-    padding: var(--space-10) var(--space-6);
-    text-align: center;
-    color: var(--color-text-muted);
-    font-size: var(--text-sm);
-    border: var(--border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--surface-raised);
-}
+/* Empty states are now the shared .data-empty component
+   (components/empty-states.css), applied via the data_empty() macro. */
 
 @media (max-width: 600px) {
     .contrib-row__link {
@@ -399,13 +391,9 @@ main.scholar-detail {
    the page reads as one coherent record, not two bolted-together features.
    ========================================================================== */
 
-/* #189 explicit empties — inline italic-subtle marker shared across the page
-   (year "n.d.", "No citation data", "No institution"). Defined here so both
-   the v1 identity header and the v2 works ledger render the contract. */
-.field-empty {
-    font-style: italic;
-    color: var(--color-text-subtle);
-}
+/* #189 explicit empties — the inline `.field-empty` marker now lives in the
+   shared components/empty-states.css so every detail page renders one contract.
+   (Year "n.d.", "No citation data", "No institution" all use it.) */
 
 /* ---- Publications stat strip (Tufte: data-dense summary, real aggregates) ---- */
 .works-stats {
@@ -560,26 +548,7 @@ main.scholar-detail {
     border-color: var(--color-badge-purple-border);
 }
 
-/* ---- #189 section-level empty ---- */
-.works-empty {
-    padding: var(--space-10) var(--space-6);
-    text-align: center;
-    color: var(--color-text-muted);
-    font-size: var(--text-sm);
-    border: var(--border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--surface-raised);
-    margin-top: var(--space-4);
-}
-.works-empty__title {
-    color: var(--color-text);
-    font-weight: var(--font-weight-medium);
-    margin-bottom: var(--space-1);
-}
-.works-empty__hint {
-    font-size: var(--text-xs);
-    color: var(--color-text-subtle);
-}
+/* #189 section-level empties use the shared .data-empty component. */
 
 /* ---- "show more" footer (server-rendered pagination) ---- */
 .works-more {

--- a/app/templates/components/_macros.html
+++ b/app/templates/components/_macros.html
@@ -648,6 +648,32 @@
 {% endmacro %}
 
 
+{# ── Standard explicit empties (#189) ─────────────────────────────────────────
+   When a record's section or field has no data, show an EXPLICIT placeholder
+   rather than silently omitting it — so the page reads as intentionally-empty,
+   not broken. Two tiers, one shared vocabulary:
+
+     data_empty(title, hint)   section/block level → "No <X> on record" + hint
+     field_empty(text)         inline field level  → an em dash / "No data"
+
+   Both render real text (.data-empty / .field-empty in empty-states.css) so a
+   screen reader announces "nothing here", not a silent gap.
+
+   Usage:
+     {{ data_empty('No readings recorded',
+                   'This sign has no attested readings in the corpus yet.') }}
+     <td>{{ ex.period or field_empty() }}</td>
+   ────────────────────────────────────────────────────────────────────────── #}
+{% macro data_empty(title='No data on record', hint=none) %}
+<div class="data-empty">
+    <p class="data-empty__title">{{ title }}</p>
+    {% if hint %}<p class="data-empty__hint">{{ hint }}</p>{% endif %}
+</div>
+{% endmacro %}
+
+{% macro field_empty(text='—') %}<span class="field-empty">{{ text }}</span>{% endmacro %}
+
+
 {# ── KPI Dashboard (progress rings) ── #}
 {% macro kpi_dashboard(kpi) %}
 {% if kpi %}

--- a/app/templates/compositions/detail.html
+++ b/app/templates/compositions/detail.html
@@ -6,6 +6,8 @@
 <link rel="stylesheet" href="/static/css/pages/compositions.css?v={{ app_version }}">
 {% endblock %}
 
+{% from "components/_macros.html" import data_empty %}
+
 {% block content %}
 <main class="composition-detail-page">
 
@@ -156,7 +158,18 @@
             </tbody>
         </table>
         {% else %}
-        <p class="compositions-empty" id="exemplars-empty">No exemplars match the current filters.</p>
+        {# #189 explicit empty. Two cases: an active filter matched nothing, or the
+           composition genuinely has no linked exemplars. The id is preserved so the
+           client-side period filter can still toggle this block. #}
+        <div id="exemplars-empty">
+            {% if filter_period or filter_provenience %}
+            {{ data_empty('No exemplars match the current filters',
+                          'Clear the period or site filter to see all linked exemplars for this composition.') }}
+            {% else %}
+            {{ data_empty('No exemplars on record',
+                          'No tablet exemplars are linked to this composition in Glintstone yet.') }}
+            {% endif %}
+        </div>
         {% endif %}
     </section>
 

--- a/app/templates/dictionary/lemma.html
+++ b/app/templates/dictionary/lemma.html
@@ -2,6 +2,8 @@
 
 {% block title %}{{ lemma.citation_form or 'Lemma' }} — Dictionary — Glintstone{% endblock %}
 
+{% from "components/_macros.html" import data_empty %}
+
 {% block content %}
 <main class="lemma-detail-page">
 
@@ -68,9 +70,9 @@
         {% endif %}
 
         {# ── Senses ──────────────────────────────────────────────────── #}
-        {% if senses %}
         <section class="dict-detail__section" aria-labelledby="senses-heading" style="margin-top: var(--space-6);">
             <h3 id="senses-heading">Senses</h3>
+            {% if senses %}
             <ol class="lemma-detail__senses">
                 {% for sense in senses %}
                 <li class="lemma-detail__sense">
@@ -91,8 +93,10 @@
                 </li>
                 {% endfor %}
             </ol>
+            {% else %}
+            {{ data_empty('No senses on record', 'No definitions or glosses have been recorded for this lemma yet.') }}
+            {% endif %}
         </section>
-        {% endif %}
 
         {# ── Sign associations ───────────────────────────────────────── #}
         {% if signs %}

--- a/app/templates/dictionary/sign.html
+++ b/app/templates/dictionary/sign.html
@@ -2,6 +2,8 @@
 
 {% block title %}{{ sign.sign_name or 'Sign' }} — Signs — Dictionary — Glintstone{% endblock %}
 
+{% from "components/_macros.html" import data_empty %}
+
 {% block content %}
 <main class="sign-detail-page">
 
@@ -38,21 +40,23 @@
     <div class="lemma-detail__body">
 
         {# ── Readings / values ───────────────────────────────────────── #}
-        {% if sign.values %}
         <section class="dict-detail__section" aria-labelledby="readings-heading">
             <h3 id="readings-heading">Readings</h3>
+            {% if sign.values %}
             <ul class="lemma-detail__readings">
                 {% for reading in sign.values %}
                 <li class="lemma-detail__reading-item">{{ reading }}</li>
                 {% endfor %}
             </ul>
+            {% else %}
+            {{ data_empty('No readings on record', 'No syllabic or logographic readings are recorded for this sign yet.') }}
+            {% endif %}
         </section>
-        {% endif %}
 
         {# ── Lemma associations ──────────────────────────────────────── #}
-        {% if lemmas %}
         <section class="dict-detail__section" aria-labelledby="lemmas-heading">
             <h3 id="lemmas-heading">Lemmas written with this sign</h3>
+            {% if lemmas %}
             <ul class="sign-detail__lemmas">
                 {% for lem in lemmas %}
                 <li class="sign-detail__lemma-row">
@@ -72,13 +76,15 @@
                 </li>
                 {% endfor %}
             </ul>
+            {% else %}
+            {{ data_empty('No lemmas on record', 'No dictionary entries are linked to this sign yet.') }}
+            {% endif %}
         </section>
-        {% endif %}
 
         {# ── Tablet occurrences — honest stub until PRD-012 ──────────── #}
         <section class="dict-detail__section" aria-labelledby="occurrences-heading">
             <h3 id="occurrences-heading">Tablet occurrences</h3>
-            <p class="dict-detail__note">Not yet indexed</p>
+            {{ data_empty('Not yet indexed', 'Sign-level tablet occurrences are not yet indexed in the Glintstone corpus.') }}
         </section>
 
         {# ── Source attribution ───────────────────────────────────────── #}

--- a/app/templates/scholars/detail.html
+++ b/app/templates/scholars/detail.html
@@ -2,6 +2,8 @@
 
 {% block title %}{{ scholar.name }} - Glintstone{% endblock %}
 
+{% from "components/_macros.html" import data_empty %}
+
 {% block head %}
 <link rel="stylesheet" href="/static/css/pages/scholars.css?v={{ app_version }}">
 {% endblock %}
@@ -150,7 +152,7 @@
           </a>
           {% endif %}
           {% if not scholar.institution and not scholar.active_since %}
-          <span>No institution or active-since on record</span>
+          <span class="field-empty">No institution or active-since on record</span>
           {% endif %}
         </div>
       </div>
@@ -305,11 +307,9 @@
     {% endif %}
 
     {% else %}
-    {# #189 section-level empty — never blank. #}
-    <div class="works-empty">
-      <p class="works-empty__title">No publications on record</p>
-      <p class="works-empty__hint">This scholar has no linked publications in the bibliography. Nothing is hidden &mdash; there is simply nothing here yet. Works are matched from CDLI/ORACC bibliography and, where an ORCID is present, can be enriched from the ORCID public record.</p>
-    </div>
+    {# #189 section-level empty — never blank. Standard data_empty component. #}
+    {{ data_empty('No publications on record',
+                  'This scholar has no linked publications in the bibliography. Nothing is hidden — there is simply nothing here yet. Works are matched from CDLI/ORACC bibliography and, where an ORCID is present, can be enriched from the ORCID public record.') }}
     {% endif %}
   </section>
 
@@ -383,9 +383,8 @@
     {% endif %}
 
     {% else %}
-    <div class="scholar-empty">
-      No artifacts are attributed to this scholar yet. Contributions appear here once an annotation run is linked.
-    </div>
+    {{ data_empty('No contributions on record',
+                  'No artifacts are attributed to this scholar yet. Contributions appear here once an annotation run is linked.') }}
     {% endif %}
   </section>
 


### PR DESCRIPTION
## #189 — explicit empty states

Consolidates the ad-hoc per-page empties into one shared component so thin-data record pages read as intentionally-empty, not broken.

**Component** (`components/_macros.html` + `components/empty-states.css`):
- `data_empty(title, hint)` — section-level block: "No <X> on record" + hint
- `field_empty(text)` — inline field-level: em dash / "No data"

Both render real text (`.data-empty` / `.field-empty`) so screen readers announce the gap.

**Applied** where sections/fields were silently omitted or inconsistent:
- `dictionary/sign` — Readings, Lemmas, Tablet-occurrences
- `dictionary/lemma` — Senses
- `scholars/detail` — publications + contributions (copy unchanged), identity fallback
- `compositions/detail` — exemplar empty (filtered-zero vs no-exemplars)

**Skipped** (intentional): `tablets/detail` (trust surface, Eric-gated), dictionary index #163 gloss empties + composition index (already good).

Gate green locally: ruff format/check, mypy (90 files), pytest 324 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)