### PR TITLE
#176: per-lemma attestation endpoint + inline attestation table

### DIFF
--- a/.claude/skills/gs-expert-data-model/migrations.md
+++ b/.claude/skills/gs-expert-data-model/migrations.md
@@ -146,6 +146,7 @@ GRANT USAGE, SELECT ON SEQUENCE my_table_id_seq TO glintstone;
 | 036 | `036_artifact_image_fetch_log_page_outcomes.sql` | Widen `outcome` check constraint on `artifact_image_fetch_log` to include page-level outcomes |
 | 037 | `037_user_roles.sql` | `role` column on `users` (admin/standard); seeds `eric.wittke@gmail.com` as admin |
 | 050 | `050_artifact_contributors.sql` | #261 junction `artifact_contributors` (p_number × scholar × role) — real per-artifact attribution parsed from `artifact_credits` prose; backs the `/scholars/{id}/contributions` ledger |
+| 052 | `052_lemmatizations_citation_form_index.sql` | #176 composite index `idx_lemmatizations_citation_form (citation_form, guide_word)` — backs the per-lemma attestation endpoint (`/dictionary/lemmas/{id}/attestations`). After Fix A/C 9x'd `lemmatizations` (65.9k → 5.4M; populated `citation_form`+`guide_word`, NOT `norm_id`/`entry_id`), the dictionary→corpus join is by citation form; this index makes it index-driven instead of a 5.4M-row seq scan |
 
 **Always confirm `migrate.py status` matches this table.** If it doesn't, update one or the other.
 

--- a/api/repositories/lexical_repo.py
+++ b/api/repositories/lexical_repo.py
@@ -934,6 +934,114 @@ class LexicalRepository(BaseRepository):
             "computed_at": row["computed_at"],
         }
 
+    def get_lemma_attestations(
+        self, lemma_id: int, page: int = 1, per_page: int = 20
+    ) -> dict | None:
+        """List the tablet lines where a lemma is actually attested (#176).
+
+        The dictionary entry (``lexical_lemmas``) is joined to the raw
+        token-level ``lemmatizations`` by their text *citation form* — there is
+        no foreign key between them. The 2026 Fix A/C backfill 9x'd
+        lemmatizations (65.9k -> 5.4M rows) but populated ``citation_form`` +
+        ``guide_word``, not ``norm_id`` (~20k rows) or ``entry_id`` (zero). So
+        ``(citation_form, guide_word)`` is the only pair that links the
+        dictionary to the corpus at scale. ``guide_word`` disambiguates
+        homographs (e.g. ``saḫ[pig]`` vs ``saḫ[clean]``); it is matched with
+        ``IS NOT DISTINCT FROM`` so a NULL guide_word on the lemma matches NULL
+        lemmatizations rather than dropping them.
+
+        The unit of attestation is the **text line**, not the raw lemmatization
+        row: a single line may carry the lemma in several tokens, or several
+        competing analyses of one token (which the schema deliberately keeps as
+        separate rows). Collapsing to the distinct line gives the scholar one
+        row per place the word occurs — the tablet + line where the lemma is
+        written, with its transliterated ATF for context.
+
+        Returns ``None`` if the lemma id does not exist (so the route can 404).
+        For an existing lemma with no attestations it returns an empty
+        ``items`` list with ``total`` 0 — the page renders the standard empty
+        state in that case.
+
+        Pagination is mandatory: a common lemma (e.g. ``šarru[king]``) occurs on
+        thousands of tablets. The index ``idx_lemmatizations_citation_form``
+        (migration 052) makes the citation-form filter index-driven.
+        """
+        lemma = self.fetch_one(
+            "SELECT citation_form, guide_word FROM lexical_lemmas WHERE id = %(id)s",
+            {"id": lemma_id},
+        )
+        if not lemma:
+            return None
+
+        params = {
+            "cf": lemma["citation_form"],
+            "gw": lemma["guide_word"],
+        }
+
+        # Distinct lines where the lemma occurs + distinct tablets behind them.
+        counts = self.fetch_one(
+            """
+            SELECT COUNT(*)                  AS total_lines,
+                   COUNT(DISTINCT p_number)  AS tablet_count
+            FROM (
+                SELECT DISTINCT tl.id, tl.p_number
+                FROM lemmatizations lz
+                JOIN tokens t       ON t.id = lz.token_id
+                JOIN text_lines tl  ON tl.id = t.line_id
+                WHERE lz.citation_form = %(cf)s
+                  AND lz.guide_word IS NOT DISTINCT FROM %(gw)s
+            ) s
+            """,
+            params,
+        )
+        total = int(counts["total_lines"]) if counts else 0
+        tablet_count = int(counts["tablet_count"]) if counts else 0
+
+        items: list[dict] = []
+        if total:
+            offset = (page - 1) * per_page
+            page_params = {**params, "limit": per_page, "offset": offset}
+            items = self.fetch_all(
+                """
+                SELECT tl.p_number,
+                       tl.line_number,
+                       tl.raw_atf,
+                       a.designation,
+                       a.period_normalized,
+                       a.provenience_normalized,
+                       a.language_normalized
+                FROM (
+                    SELECT DISTINCT tl.id,
+                           tl.p_number,
+                           tl.line_number,
+                           tl.raw_atf,
+                           tl.column_number
+                    FROM lemmatizations lz
+                    JOIN tokens t      ON t.id = lz.token_id
+                    JOIN text_lines tl ON tl.id = t.line_id
+                    WHERE lz.citation_form = %(cf)s
+                      AND lz.guide_word IS NOT DISTINCT FROM %(gw)s
+                ) tl
+                JOIN artifacts a ON a.p_number = tl.p_number
+                ORDER BY tl.p_number, tl.column_number, tl.line_number
+                LIMIT %(limit)s OFFSET %(offset)s
+                """,
+                page_params,
+            )
+
+        total_pages = (total + per_page - 1) // per_page if total else 0
+        return {
+            "lemma_id": lemma_id,
+            "citation_form": lemma["citation_form"],
+            "guide_word": lemma["guide_word"],
+            "items": [dict(r) for r in items],
+            "total": total,
+            "tablet_count": tablet_count,
+            "page": page,
+            "per_page": per_page,
+            "total_pages": total_pages,
+        }
+
     # ── Helpers ───────────────────────────────────────────────
 
     @staticmethod

--- a/api/routes/dictionary.py
+++ b/api/routes/dictionary.py
@@ -112,6 +112,29 @@ def lookup_written_form(
     return repo.lookup_by_written_form(form, language)
 
 
+@router.get("/lemmas/{lemma_id}/attestations")
+def get_lemma_attestations(
+    lemma_id: int,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    conn=Depends(get_db),
+):
+    """Tablet lines where this lemma is attested (#176).
+
+    Each row is one text line where the lemma occurs, carrying its P-number,
+    designation, line reference, transliterated ATF, and (where known) period /
+    provenience / language. Paginated — a common lemma can occur on thousands
+    of tablets. Returns ``items`` empty (not 404) for an existing lemma with no
+    attestations so the page can render its empty state; 404 only for a
+    non-existent lemma id.
+    """
+    repo = LexicalRepository(conn)
+    result = repo.get_lemma_attestations(lemma_id, page=page, per_page=per_page)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Lemma not found")
+    return result
+
+
 @router.get("/lemmas/{lemma_id}/norms")
 def get_lemma_norms(lemma_id: int, conn=Depends(get_db)):
     """Get all normalized forms and their written spellings for a lemma."""

--- a/app/routes/dictionary.py
+++ b/app/routes/dictionary.py
@@ -110,7 +110,7 @@ def dictionary_index(
 
 
 @router.get("/lemmas/{lemma_id}")
-def lemma_detail(request: Request, lemma_id: int):
+def lemma_detail(request: Request, lemma_id: int, page: int = Query(1, ge=1)):
     api = request.app.state.api
     try:
         data = api.get(f"/dictionary/lemmas/{lemma_id}")
@@ -128,6 +128,18 @@ def lemma_detail(request: Request, lemma_id: int):
     except Exception:
         norms = []
 
+    # Inline attestation table (#176) — the tablet lines where this lemma is
+    # actually written, replacing the old count+jump card. Third, non-fatal
+    # call: if the attestation endpoint is unavailable the page still renders
+    # (the table falls back to the empty state rather than 500ing).
+    try:
+        attestations = api.get(
+            f"/dictionary/lemmas/{lemma_id}/attestations",
+            params={"page": page, "per_page": 20},
+        )
+    except Exception:
+        attestations = None
+
     from app.main import templates
 
     return templates.TemplateResponse(
@@ -138,7 +150,7 @@ def lemma_detail(request: Request, lemma_id: int):
             "senses": data.get("senses", []),
             "signs": data.get("signs", []),
             "norms": norms,
-            "tablet_count": data.get("tablet_count"),
+            "attestations": attestations or {},
             "api_url": request.app.state.api.base_url,
         },
     )

--- a/app/static/css/pages/dictionary.css
+++ b/app/static/css/pages/dictionary.css
@@ -1031,8 +1031,108 @@
 .attestation-jump--unindexed .attestation-jump__count,
 .attestation-jump--unindexed .attestation-jump__arrow { color: var(--color-text-subtle); }
 
+/* ── Inline attestation table (#176) ──────────────────────────────────────── */
+.lemma-attestations__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+.lemma-attestations__count {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.lemma-attestations__hint {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    margin: var(--space-1) 0 var(--space-3);
+}
+.attestation-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-top: var(--border-default);
+}
+.attestation-row {
+    border-bottom: var(--border-default);
+}
+.attestation-row__link {
+    display: flex;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-2);
+    color: var(--color-text);
+    text-decoration: none;
+    transition: background var(--transition-normal);
+}
+.attestation-row__link:hover { background: var(--color-accent-10); }
+.attestation-row__ref {
+    flex-shrink: 0;
+    width: 7.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.attestation-row__pnum {
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-accent);
+    font-variant-numeric: tabular-nums;
+}
+.attestation-row__line {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+}
+.attestation-row__main { min-width: 0; }
+.attestation-row__atf {
+    display: block;
+    font-family: var(--font-mono, monospace);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    word-break: break-word;
+}
+.attestation-row__atf--empty { font-family: inherit; }
+.attestation-row__tablet {
+    display: block;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    margin-top: 2px;
+}
+.attestation-row__tags {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    margin-top: var(--space-1);
+}
+.attestation-row__facet {
+    font-size: var(--text-xs);
+    color: var(--color-text-subtle);
+    background: var(--surface-raised);
+    border: var(--border-default);
+    border-radius: var(--radius-sm);
+    padding: 0 var(--space-1);
+}
+.lemma-attestations__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    margin-top: var(--space-4);
+}
+.lemma-attestations__seeall {
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-accent);
+    text-decoration: none;
+}
+.lemma-attestations__seeall:hover { text-decoration: underline; }
+
 @media (max-width: 768px) {
     .lemma-detail__columns { grid-template-columns: 1fr; }
     .morphology { position: static; }
+    .attestation-row__link { flex-direction: column; gap: var(--space-1); }
+    .attestation-row__ref { flex-direction: row; width: auto; gap: var(--space-2); }
 }
 

--- a/app/templates/dictionary/lemma.html
+++ b/app/templates/dictionary/lemma.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ lemma.citation_form or 'Lemma' }} — Dictionary — Glintstone{% endblock %}
 
-{% from "components/_macros.html" import data_empty %}
+{% from "components/_macros.html" import data_empty, field_empty %}
 
 {% block content %}
 <main class="lemma-detail-page">
@@ -49,25 +49,82 @@
         {# ── Main column ─────────────────────────────────────────────── #}
         <div class="lemma-detail__main">
 
-        {# ── Attestation jump — primary next action, top of main ─────── #}
-        {% if tablet_count %}
-        <a class="attestation-jump" href="/tablets?search={{ lemma.citation_form | urlencode }}">
-            <span class="attestation-jump__text">
-                <span class="attestation-jump__label">See {{ lemma.citation_form }} in tablets</span>
-                <span class="attestation-jump__sub">Browse indexed tablets where this lemma occurs</span>
-            </span>
-            <span class="attestation-jump__count">{{ '{:,}'.format(tablet_count) }}</span>
-            <span class="attestation-jump__arrow" aria-hidden="true">›</span>
-        </a>
-        {% else %}
-        <span class="attestation-jump attestation-jump--unindexed">
-            <span class="attestation-jump__text">
-                <span class="attestation-jump__label">Tablet occurrences</span>
-                <span class="attestation-jump__sub">Not yet indexed in the Glintstone corpus</span>
-            </span>
-            <span class="attestation-jump__count">—</span>
-        </span>
-        {% endif %}
+        {# ── Attestations — inline table of the lines where this lemma is
+             actually written (#176), replacing the old count+jump card.
+             ``attestations`` is the /attestations API payload: items (one row
+             per text line), total (distinct lines), tablet_count (distinct
+             tablets), page / total_pages. ─────────────────────────────────── #}
+        {% set att_items = attestations.get('items', []) %}
+        {% set att_total = attestations.get('total', 0) %}
+        {% set att_tablets = attestations.get('tablet_count', 0) %}
+        {% set att_page = attestations.get('page', 1) %}
+        {% set att_pages = attestations.get('total_pages', 0) %}
+        <section class="dict-detail__section lemma-attestations" aria-labelledby="attestations-heading">
+            <div class="lemma-attestations__head">
+                <h3 id="attestations-heading">Attestations</h3>
+                {% if att_total %}
+                <span class="lemma-attestations__count">
+                    {{ '{:,}'.format(att_total) }} line{{ '' if att_total == 1 else 's' }}
+                    across {{ '{:,}'.format(att_tablets) }} tablet{{ '' if att_tablets == 1 else 's' }}
+                </span>
+                {% endif %}
+            </div>
+
+            {% if att_items %}
+            <p class="lemma-attestations__hint">Lines in the corpus where <em>{{ lemma.citation_form }}</em> is written, with the transliterated text and tablet.</p>
+            <ul class="attestation-list">
+                {% for a in att_items %}
+                <li class="attestation-row">
+                    <a class="attestation-row__link" href="/tablets/{{ a.p_number }}">
+                        <span class="attestation-row__ref">
+                            <span class="attestation-row__pnum">{{ a.p_number }}</span>
+                            <span class="attestation-row__line">{{ ('l. ' ~ a.line_number) if a.line_number else field_empty('—') }}</span>
+                        </span>
+                        <span class="attestation-row__main">
+                            {% if a.raw_atf %}
+                            <span class="attestation-row__atf" lang="akk" dir="ltr">{{ a.raw_atf }}</span>
+                            {% else %}
+                            <span class="attestation-row__atf attestation-row__atf--empty">{{ field_empty('No transliteration on record') }}</span>
+                            {% endif %}
+                            <span class="attestation-row__tablet">{{ a.designation or a.p_number }}</span>
+                            {% set facets = [] %}
+                            {% if a.period_normalized %}{% set _ = facets.append(a.period_normalized) %}{% endif %}
+                            {% if a.provenience_normalized %}{% set _ = facets.append(a.provenience_normalized) %}{% endif %}
+                            {% if a.language_normalized %}{% set _ = facets.append(a.language_normalized) %}{% endif %}
+                            {% if facets %}
+                            <span class="attestation-row__tags">
+                                {% for f in facets %}<span class="attestation-row__facet">{{ f }}</span>{% endfor %}
+                            </span>
+                            {% endif %}
+                        </span>
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+
+            {# Pagination — same query (page param), preserved across the page.
+               'See all in tablets' jumps to the full filtered tablet browse. #}
+            <div class="lemma-attestations__footer">
+                {% if att_pages > 1 %}
+                <nav class="pagination" aria-label="Attestation pages">
+                    {% if att_page > 1 %}
+                    <a href="/dictionary/lemmas/{{ lemma.id }}?page={{ att_page - 1 }}#attestations-heading" class="btn">Previous</a>
+                    {% endif %}
+                    <span class="page-info">Page {{ att_page }} of {{ '{:,}'.format(att_pages) }}</span>
+                    {% if att_page < att_pages %}
+                    <a href="/dictionary/lemmas/{{ lemma.id }}?page={{ att_page + 1 }}#attestations-heading" class="btn">Next</a>
+                    {% endif %}
+                </nav>
+                {% endif %}
+                <a class="lemma-attestations__seeall" href="/tablets?search={{ lemma.citation_form | urlencode }}">
+                    See all {{ lemma.citation_form }} in tablets ›
+                </a>
+            </div>
+            {% else %}
+            {{ data_empty('No attestations on record',
+                          'This lemma has no lemmatized occurrences in the corpus yet. Attestations appear here once tokens on a tablet are linked to this dictionary entry.') }}
+            {% endif %}
+        </section>
 
         {# ── Senses ──────────────────────────────────────────────────── #}
         <section class="dict-detail__section" aria-labelledby="senses-heading" style="margin-top: var(--space-6);">

--- a/data-model/migrations/052_lemmatizations_citation_form_index.sql
+++ b/data-model/migrations/052_lemmatizations_citation_form_index.sql
@@ -1,0 +1,45 @@
+-- Migration 052: Index lemmatizations(citation_form, guide_word)
+--
+-- Backs the new per-lemma attestation endpoint (#176). The lemma detail page
+-- now renders an INLINE table of the tablets/lines where a lemma actually
+-- occurs, replacing the old count+jump card. That table joins the dictionary
+-- entry (lexical_lemmas) to the raw token-level lemmatizations by their text
+-- citation form, then walks tokens -> text_lines -> artifacts:
+--
+--     lexical_lemmas.citation_form (+ guide_word)
+--        = lemmatizations.citation_form (+ guide_word)
+--          -> tokens.id  (lemmatizations.token_id)
+--          -> tokens.line_id -> text_lines.id
+--          -> text_lines.p_number -> artifacts.p_number
+--
+-- Why the text join rather than a foreign key: lemmatizations has no FK to
+-- lexical_lemmas. The 2026 Fix A/C backfill 9x'd lemmatizations (65.9k ->
+-- 5.4M rows) but populated citation_form + guide_word, NOT norm_id (only ~20k
+-- rows carry norm_id) and NOT entry_id (zero rows). So citation_form +
+-- guide_word is the only column pair that links the dictionary to the corpus
+-- at scale. guide_word disambiguates homographs (e.g. sah[pig] vs sah[clean]).
+--
+-- Without this index, COUNT(DISTINCT p_number) and the paginated page each
+-- seq-scan the 5.4M-row lemmatizations table (~1.8 s on prod for a common
+-- lemma like sarru[king], which has 65k occurrences across 6.6k tablets).
+-- The composite (citation_form, guide_word) index makes the WHERE filter
+-- index-driven, taking the lookup to single-digit ms before the token/line
+-- hydration.
+--
+-- Idempotent: IF NOT EXISTS makes this a no-op if the index was already
+-- created live on prod with CREATE INDEX CONCURRENTLY. It deliberately does
+-- NOT use CONCURRENTLY here because the migration runner wraps each file in a
+-- transaction and CONCURRENTLY cannot run inside a transaction block.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_lemmatizations_citation_form
+    ON lemmatizations (citation_form, guide_word);
+
+COMMENT ON INDEX idx_lemmatizations_citation_form IS
+    'Backs the per-lemma attestation lookup (#176): joins lexical_lemmas to '
+    'lemmatizations by (citation_form, guide_word) to list the tablets/lines '
+    'where a dictionary lemma occurs. Makes the filter index-driven instead of '
+    'a 5.4M-row seq scan.';
+
+COMMIT;

--- a/tests/unit/test_lexical_repo_attestations.py
+++ b/tests/unit/test_lexical_repo_attestations.py
@@ -1,0 +1,86 @@
+"""Unit tests for LexicalRepository.get_lemma_attestations (#176).
+
+These exercise the orchestration logic — 404 vs empty, pagination math, and
+the shape of the returned payload — without a live database by stubbing the
+two fetch helpers the method calls. The actual SQL is validated against prod
+in the build's data-availability gate; here we lock the contract the route and
+template depend on.
+"""
+
+from __future__ import annotations
+
+from api.repositories.lexical_repo import LexicalRepository
+
+
+def _repo() -> LexicalRepository:
+    # The base __init__ only stores the connection; we never touch it because
+    # every fetch_* is stubbed per-test.
+    return LexicalRepository(conn=None)  # type: ignore[arg-type]
+
+
+def test_missing_lemma_returns_none():
+    """A non-existent lemma id yields None so the route can 404."""
+    repo = _repo()
+    repo.fetch_one = lambda sql, params=(): None  # type: ignore[assignment]
+    assert repo.get_lemma_attestations(999999) is None
+
+
+def test_existing_lemma_no_attestations_returns_empty_items():
+    """An existing lemma with zero occurrences returns an empty list, not None
+    — so the page renders the standard empty state rather than a 404."""
+    repo = _repo()
+    calls = {"n": 0}
+
+    def fake_one(sql, params=()):
+        calls["n"] += 1
+        if calls["n"] == 1:  # lemma lookup
+            return {"citation_form": "ḫapû", "guide_word": "rare"}
+        return {"total_lines": 0, "tablet_count": 0}  # counts
+
+    repo.fetch_one = fake_one  # type: ignore[assignment]
+    repo.fetch_all = lambda sql, params=(): []  # type: ignore[assignment]
+
+    result = repo.get_lemma_attestations(42)
+    assert result is not None
+    assert result["items"] == []
+    assert result["total"] == 0
+    assert result["tablet_count"] == 0
+    assert result["total_pages"] == 0
+    assert result["citation_form"] == "ḫapû"
+
+
+def test_pagination_math_and_payload_shape():
+    """Totals drive total_pages; the page of rows is passed through verbatim."""
+    repo = _repo()
+    calls = {"n": 0}
+    rows = [
+        {
+            "p_number": "P202351",
+            "line_number": "5",
+            "raw_atf": "ina E₂ ...",
+            "designation": "CT 56, 004",
+            "period_normalized": None,
+            "provenience_normalized": None,
+            "language_normalized": "Akkadian",
+        }
+    ]
+
+    def fake_one(sql, params=()):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {"citation_form": "bītu", "guide_word": "house"}
+        return {"total_lines": 45, "tablet_count": 12}
+
+    repo.fetch_one = fake_one  # type: ignore[assignment]
+    repo.fetch_all = lambda sql, params=(): rows  # type: ignore[assignment]
+
+    result = repo.get_lemma_attestations(7, page=2, per_page=20)
+    assert result is not None
+    assert result["total"] == 45
+    assert result["tablet_count"] == 12
+    # 45 rows at 20/page -> 3 pages
+    assert result["total_pages"] == 3
+    assert result["page"] == 2
+    assert result["per_page"] == 20
+    assert result["items"] == rows
+    assert result["guide_word"] == "house"


### PR DESCRIPTION
## What
Replaces the lemma detail page's count+jump attestation card with a real **inline attestation table** — the actual tablet lines where a lemma is written — backed by a new paginated endpoint.

## Why now (data-availability gate)
The original count+jump (#161) existed because lemmatization coverage was ~2% and there was no per-lemma tablet list. **Fix A/C 9x'd lemmatizations** (65,906 → 5,410,658 rows). On prod, common lemmas now carry rich attestations:
- `šarru[king]` → 18,774 distinct lines across 6,653 tablets (65,363 raw occurrences)
- `bītu[house]` → 21,611 occurrences across 2,571 tablets

The inline table is worth building.

## How
- `GET /dictionary/lemmas/{id}/attestations` — paginated; returns p_number, designation, line ref, transliterated ATF, period/provenience/language. Joins `lexical_lemmas` → `lemmatizations` by `(citation_form, guide_word)` (the only pair the Fix A/C backfill populated — `norm_id` ~20k rows, `entry_id` zero). The attestation unit is the **distinct text line**, so competing analyses collapse to one row. Empty items (not 404) for an existing lemma with no attestations.
- **Migration 052**: composite index `idx_lemmatizations_citation_form (citation_form, guide_word)` — takes the count from ~1.8s to ~0.2s on prod (already created live on prod with `CREATE INDEX CONCURRENTLY` as `wittkensis`; migration is `IF NOT EXISTS`, a no-op there).
- Web: `lemma.html` swaps the `attestation-jump` card for an inline list (top 20 + pagination + "see all in tablets"), reusing the #189 `data_empty` empty-state component.

## Verification
- ruff format/check, mypy (`api app core mcp --ignore-missing-imports`), pytest: all green (327 passed, +3 new unit tests).
- Render-verified headless against a local DB: the inline table on `šarru[king]` (26 lines / 13 tablets in fixture), the empty state on `a[bird-cry]`.
- Does NOT read the `pipeline_completeness` view (#257 landmine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)