### PR TITLE
#159: ATF preview on composition detail — representative exemplar transliteration

### DIFF
--- a/api/repositories/composite_repo.py
+++ b/api/repositories/composite_repo.py
@@ -93,6 +93,78 @@ class CompositeRepository(BaseRepository):
             {"q_number": q_number},
         )
 
+    def get_representative_atf_preview(
+        self, q_number: str, limit: int = 8
+    ) -> dict | None:
+        """Preview of a representative exemplar's transliterated text (#159).
+
+        The composition detail page shows the actual cuneiform transliteration
+        (ATF) of one well-preserved exemplar so a reader can see real text, not
+        just a list of P-numbers. We pick the *representative* exemplar as the
+        linked tablet carrying the most non-empty, non-structural ATF lines —
+        i.e. the most complete witness we hold — then return that tablet's first
+        ``limit`` readable lines in document order.
+
+        "Readable" excludes ATF structural/metadata lines (those beginning with
+        ``$`` strict/loose state notes, ``@`` surface markers, ``&`` headers,
+        ``#`` comments) so the preview opens on actual transliterated signs
+        rather than a "beginning broken" annotation. The ``raw_atf`` text itself
+        is returned verbatim — prime notation, damage brackets ``[...]``, and
+        half-bracket damage ``#`` on signs are all preserved exactly as stored.
+
+        Returns ``None`` when no linked exemplar has any readable ATF line, so
+        the caller renders the #189 empty state. Never reads
+        ``pipeline_completeness`` (it is unreliable — #257).
+        """
+        # Step 1: choose the representative exemplar — most readable ATF lines.
+        rep = self.fetch_one(
+            r"""
+            SELECT ac.p_number,
+                   a.designation,
+                   a.period,
+                   a.provenience,
+                   count(*) AS atf_line_count
+            FROM artifact_composites ac
+            JOIN text_lines tl ON tl.p_number = ac.p_number
+            JOIN artifacts a ON a.p_number = ac.p_number
+            WHERE ac.q_number = %(q_number)s
+              AND tl.raw_atf IS NOT NULL
+              AND tl.raw_atf <> ''
+              AND tl.raw_atf !~ '^[$@&#]'
+            GROUP BY ac.p_number, a.designation, a.period, a.provenience
+            ORDER BY atf_line_count DESC, ac.p_number
+            LIMIT 1
+            """,
+            {"q_number": q_number},
+        )
+        if not rep:
+            return None
+
+        # Step 2: that exemplar's first N readable lines, in document order.
+        lines = self.fetch_all(
+            r"""
+            SELECT tl.line_number, tl.raw_atf
+            FROM text_lines tl
+            WHERE tl.p_number = %(p_number)s
+              AND tl.raw_atf IS NOT NULL
+              AND tl.raw_atf <> ''
+              AND tl.raw_atf !~ '^[$@&#]'
+            ORDER BY tl.column_number, tl.id
+            LIMIT %(limit)s
+            """,
+            {"p_number": rep["p_number"], "limit": limit},
+        )
+
+        return {
+            "p_number": rep["p_number"],
+            "designation": rep["designation"],
+            "period": rep["period"],
+            "provenience": rep["provenience"],
+            "total_atf_lines": rep["atf_line_count"],
+            "preview_line_count": len(lines),
+            "lines": lines,
+        }
+
     def get_total_count(self) -> int:
         """
         Get total number of composites.

--- a/api/routes/composites.py
+++ b/api/routes/composites.py
@@ -59,7 +59,41 @@ def get_composite(q_number: str, conn=Depends(get_db)):
 
     exemplars = repo.get_exemplars(q_number)
 
-    return {"composite": composite, "exemplars": exemplars}
+    # ATF preview (#159): the transliterated text of a representative exemplar,
+    # shown inline on the composition detail page. None when no linked exemplar
+    # carries readable ATF, so the page renders its #189 empty state.
+    atf_preview = repo.get_representative_atf_preview(q_number)
+
+    return {
+        "composite": composite,
+        "exemplars": exemplars,
+        "atf_preview": atf_preview,
+    }
+
+
+@router.get("/{q_number}/atf-preview")
+def get_composite_atf_preview(
+    q_number: str,
+    limit: int = Query(8, ge=1, le=40, description="Lines to preview"),
+    conn=Depends(get_db),
+):
+    """Transliterated-text preview of a representative exemplar (#159).
+
+    Picks the linked exemplar with the most readable ATF lines and returns its
+    first ``limit`` lines verbatim (prime notation, damage brackets preserved).
+    ``atf_preview`` is ``null`` for a composite with no readable-ATF exemplar
+    (the page renders the #189 empty state); 404 only for an unknown Q-number.
+    """
+    repo = CompositeRepository(conn)
+
+    composite = repo.find_by_q_number(q_number)
+    if not composite:
+        raise HTTPException(status_code=404, detail=f"Composite {q_number} not found")
+
+    return {
+        "q_number": q_number,
+        "atf_preview": repo.get_representative_atf_preview(q_number, limit=limit),
+    }
 
 
 @router.get("/{q_number}/exemplars")

--- a/app/routes/compositions.py
+++ b/app/routes/compositions.py
@@ -107,10 +107,12 @@ def composition_detail(
     if isinstance(composite, dict) and "composite" in composite:
         composite_meta = composite.get("composite") or {}
         all_exemplars = composite.get("exemplars", [])
+        atf_preview = composite.get("atf_preview")
     else:
         composite_meta = composite if isinstance(composite, dict) else {}
         exemplars_data = api.get_composite_exemplars(q_number)
         all_exemplars = exemplars_data.get("exemplars", [])
+        atf_preview = None
 
     linked_count = len(all_exemplars)
 
@@ -209,6 +211,7 @@ def composition_detail(
         {
             "composite": composite_meta,
             "exemplars": filtered,
+            "atf_preview": atf_preview,
             "timeline_exemplars": timeline_exemplars,
             "linked_count": linked_count,
             "oracc_count": oracc_count,

--- a/app/static/css/pages/compositions.css
+++ b/app/static/css/pages/compositions.css
@@ -497,6 +497,58 @@
 }
 
 /* ==========================================================================
+   Transliteration preview (#159) — reuses #176 .attestation-row/.attestation-list
+   inline-ATF rendering (globally available via dictionary.css). Only the
+   section chrome lives here.
+   ========================================================================== */
+
+.composition-detail__atf-preview {
+    margin-bottom: var(--space-8);
+}
+
+.composition-detail__atf-preview-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-2);
+}
+
+.composition-detail__atf-preview h2 {
+    font-size: var(--text-base);
+    font-weight: 600;
+    margin: 0;
+}
+
+.composition-detail__atf-preview-count {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.composition-detail__atf-preview-hint {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    margin: 0 0 var(--space-3);
+}
+
+.composition-detail__atf-preview-footer {
+    margin-top: var(--space-3);
+}
+
+.composition-detail__atf-preview-full {
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-accent);
+    text-decoration: none;
+}
+
+.composition-detail__atf-preview-full:hover {
+    text-decoration: underline;
+}
+
+/* ==========================================================================
    Transmission History Timeline — SVG container
    ========================================================================== */
 

--- a/app/templates/compositions/detail.html
+++ b/app/templates/compositions/detail.html
@@ -94,6 +94,54 @@
     </section>
     {% endif %}
 
+    {# ── Transliteration preview (#159) ──────────────────────────────────────
+         The actual cuneiform transliteration (ATF) of a representative exemplar
+         — the linked tablet that carries the most readable lines — so a reader
+         sees real text, not just a list of P-numbers. Reuses the #176 inline
+         attestation rendering: ``raw_atf`` shown verbatim (prime notation and
+         damage brackets preserved). ``atf_preview`` is null when no linked
+         exemplar has readable ATF → #189 empty state. ──────────────────────── #}
+    <section class="composition-detail__atf-preview" aria-labelledby="atf-preview-heading">
+        <div class="composition-detail__atf-preview-header">
+            <h2 id="atf-preview-heading">Transliteration preview</h2>
+            {% if atf_preview and atf_preview.lines %}
+            <span class="composition-detail__atf-preview-count">
+                First {{ atf_preview.preview_line_count }} of
+                {{ "{:,}".format(atf_preview.total_atf_lines) }} line{{ '' if atf_preview.total_atf_lines == 1 else 's' }}
+            </span>
+            {% endif %}
+        </div>
+
+        {% if atf_preview and atf_preview.lines %}
+        <p class="composition-detail__atf-preview-hint">
+            Transliterated text of a representative exemplar —
+            <a href="/tablets/{{ atf_preview.p_number }}">{{ atf_preview.designation or atf_preview.p_number }}</a>{% if atf_preview.period %}, {{ atf_preview.period }}{% endif %}{% if atf_preview.provenience %} ({{ atf_preview.provenience }}){% endif %}.
+        </p>
+        <ul class="attestation-list">
+            {% for line in atf_preview.lines %}
+            <li class="attestation-row">
+                <a class="attestation-row__link" href="/tablets/{{ atf_preview.p_number }}">
+                    <span class="attestation-row__ref">
+                        <span class="attestation-row__line">{{ ('l. ' ~ line.line_number) if line.line_number else '—' }}</span>
+                    </span>
+                    <span class="attestation-row__main">
+                        <span class="attestation-row__atf" lang="akk" dir="ltr">{{ line.raw_atf }}</span>
+                    </span>
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+        <div class="composition-detail__atf-preview-footer">
+            <a class="composition-detail__atf-preview-full" href="/tablets/{{ atf_preview.p_number }}">
+                Read the full tablet ›
+            </a>
+        </div>
+        {% else %}
+        {{ data_empty('No transliteration available yet',
+                      'None of this composition\'s linked exemplars carry a transliteration in Glintstone yet. A preview of the text appears here once an exemplar with transliterated lines is linked.') }}
+        {% endif %}
+    </section>
+
     {# ── Exemplar List ──────────────────────────────────────────────────────── #}
     <section class="composition-detail__exemplars" aria-labelledby="exemplars-heading">
         <div class="composition-detail__exemplars-header">


### PR DESCRIPTION
## What

Adds a **Transliteration preview** to the composition (composite) detail page: the actual cuneiform transliteration (ATF) of a representative exemplar — now viable because Fix A populated `text_lines` for ORACC tablets.

Reuses the **#176 inline-attestation** rendering: `raw_atf` shown verbatim, prime notation and damage brackets preserved exactly.

## Data-availability gate (prod)

- 2,375,097 `text_lines`; 116,765 artifacts with non-empty `raw_atf`.
- 659 composites have linked exemplars in `artifact_composites`; **all 659 (100%) have at least one readable-ATF exemplar**. Canon top-20 all covered.
- The 8,107 link-less composites (ORACC `exemplar_count` only, no P-number links) render the #189 empty state — no fabrication.

## How

- `CompositeRepository.get_representative_atf_preview()` — picks the linked exemplar with the most readable ATF lines (excludes `$/@/&/#` structural lines so the preview opens on real signs), returns its first N lines in document order. `None` → empty state. Does **not** read `pipeline_completeness` (#257).
- Extends `GET /composites/{q}` with `atf_preview`; adds `GET /composites/{q}/atf-preview`.
- `detail.html` renders via the global `.attestation-row`/`.attestation-list` classes (#176), with the #189 "No transliteration available yet" fallback.

## Verification

- Gate: `ruff format --check`, `ruff check`, `mypy` (changed files clean), `pytest` 336 passed / 35 DB-skipped.
- Render-verified against real prod data: Q000782 "instructions of Šuruppak" (8 of 92 lines, rep exemplar CUSAS 40 0600, prime/damage notation intact) and an empty-state composition (Q005465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)