### PR TITLE
Fix #332: timeline tick labels show BCE for BCE dates

### DIFF
--- a/api/repositories/period_repo.py
+++ b/api/repositories/period_repo.py
@@ -18,8 +18,10 @@ class PeriodRepository(BaseRepository):
         """Return one row per canonical period, ordered chronologically.
 
         Each row: {canonical, date_start_bce, date_end_bce, sort_order,
-        group_name}. BCE dates are stored as negative integers (or null when
-        a period has no agreed range, e.g. "Uncertain"). Rows are ordered by
+        group_name}. BCE dates are stored as POSITIVE integers (e.g. 2100 =
+        2100 BCE) and the few genuinely-CE dates as NEGATIVE integers (e.g.
+        -224 = 224 CE, the Parthian/Sassanian boundary); null when a period
+        has no agreed range, e.g. "Uncertain". Rows are ordered by
         sort_order (nulls last) so the consumer can lay them out left-to-right
         in chronological order without re-sorting.
         """

--- a/app/static/js/lemma-period-timeline.js
+++ b/app/static/js/lemma-period-timeline.js
@@ -62,11 +62,18 @@ function lptFetchOrder() {
     return _lptPeriodsPromise;
 }
 
-/** Format a BCE year (negative integer) as a human label: -2000 -> "2000". */
+/**
+ * Format a period_canon year as a human era label.
+ *
+ * period_canon stores BCE years as POSITIVE integers (e.g. 2100 = 2100 BCE,
+ * the Ur III period) and the few genuinely-CE years as NEGATIVE integers
+ * (e.g. -224 = 224 CE, the end of the Parthian period / start of Sassanian).
+ * So the era suffix is the inverse of the sign: positive → BCE, negative → CE.
+ */
 function lptFormatYear(year) {
-    if (year < 0) return String(-year);
-    if (year === 0) return '0';
-    return year + ' CE';
+    if (year > 0) return year + ' BCE';
+    if (year < 0) return (-year) + ' CE';
+    return '0';
 }
 
 /**
@@ -219,7 +226,7 @@ LemmaPeriodTimeline.prototype._render = function () {
             p.period + ': ' + p.tablet_count + ' tablet'
             + (p.tablet_count === 1 ? '' : 's') + ' ('
             + lptFormatYear(p.date_start_bce) + '–' + lptFormatYear(p.date_end_bce)
-            + ' BCE)'
+            + ')'
         );
 
         // Count label centred above the bar (skipped if the bar is too narrow).
@@ -238,7 +245,7 @@ LemmaPeriodTimeline.prototype._render = function () {
                 var label = period.period + ' · ' + period.tablet_count
                     + ' tablet' + (period.tablet_count === 1 ? '' : 's')
                     + ' · ' + lptFormatYear(period.date_start_bce) + '–'
-                    + lptFormatYear(period.date_end_bce) + ' BCE';
+                    + lptFormatYear(period.date_end_bce);
                 tipText.textContent = label;
                 tooltip.setAttribute('display', 'block');
                 var textW = Math.min(label.length * 6.0, 360);

--- a/app/static/js/transmission-timeline.js
+++ b/app/static/js/transmission-timeline.js
@@ -32,8 +32,9 @@ var _periodsPromise = null;
 
 /**
  * Fetch canonical periods from the app's /_periods proxy and reshape into the structures the
- * timeline needs: a {canonical -> [start, end]} range map (BCE = negative,
- * null when a period has no agreed range) and a chronological display order.
+ * timeline needs: a {canonical -> [start, end]} range map (BCE = positive,
+ * CE = negative; null when a period has no agreed range) and a chronological
+ * display order.
  * Resolves to { ranges, order } even on failure (empty structures), so callers
  * can fall back gracefully rather than throwing.
  */
@@ -174,13 +175,17 @@ TransmissionTimeline.prototype._axisTicks = function (dateRange) {
 };
 
 /**
- * Format a BCE year (negative integer) as a human label, e.g. -2000 -> "2000".
- * Positive years (rare, e.g. Parthian end) are suffixed CE.
+ * Format a period_canon year as a human era label.
+ *
+ * period_canon stores BCE years as POSITIVE integers (e.g. 2100 = 2100 BCE)
+ * and the few genuinely-CE years as NEGATIVE integers (e.g. -224 = 224 CE,
+ * the end of the Parthian period). So the era suffix is the inverse of the
+ * sign: positive → BCE, negative → CE.
  */
 function formatYear(year) {
-    if (year < 0) return String(-year);
-    if (year === 0) return '0';
-    return year + ' CE';
+    if (year > 0) return year + ' BCE';
+    if (year < 0) return (-year) + ' CE';
+    return '0';
 }
 
 TransmissionTimeline.prototype._render = function () {


### PR DESCRIPTION
## Bug

Timeline axis tick labels rendered "<year> CE" for BCE dates — e.g. the Ur III period (2100 BCE) showed as "2100 CE". Assyriologist-facing dates were wrong on three live timelines.

## Root cause

`period_canon` stores **BCE years as POSITIVE integers** and the few genuinely-CE years as **NEGATIVE integers** (verified against production: Ur III start = 2100; Parthian = 247 → -224 i.e. 247 BCE to 224 CE; Sassanian -224 → -641 = 224 to 641 CE). The `lptFormatYear` / `formatYear` axis-label functions had the sign logic inverted.

## Fix

Invert the era suffix: positive → BCE, negative → CE. This preserves genuine CE periods (Parthian/Sassanian straddle the era boundary) instead of blindly flipping the suffix.

- `app/static/js/lemma-period-timeline.js` — #201 lemma timeline + #157 scholar activity (shared container)
- `app/static/js/transmission-timeline.js` — #195, shared the identical bug
- `api/repositories/period_repo.py` — corrected docstring that wrongly claimed BCE = negative

Bars were already positioned correctly (magnitude-relative axis); only the tick suffix was wrong.

## Verify

- ruff + mypy clean; `test_lexical_repo_attestation_periods` passes.
- Render-verified the actual fixed JS render path against real `period_canon` values: šarru (469865) ticks now read 2000 BCE…1000 BCE; scholar 792 (Parthian/Sassanian) reads BCE early, CE late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)