### PR TITLE
feat(atf): stamp token_id on aligned /atf words to activate interpret_token (#330)

### DIFF
--- a/api/repositories/artifact_repo.py
+++ b/api/repositories/artifact_repo.py
@@ -594,10 +594,19 @@ class ArtifactRepository(BaseRepository):
         )
 
     def get_atf(self, p_number: str) -> dict:
-        """Get ATF text lines for a tablet."""
+        """Get ATF text lines for a tablet.
+
+        Carries ``line_id`` (text_lines.id) on every line so the parser can map
+        each line's parsed words to its ``tokens`` rows for token_id stamping
+        (#330). ``tokens_by_line`` maps line_id -> ordered token rows
+        (position, raw_form, id); the parser aligns words to tokens by
+        normalized raw_form match and only stamps when the alignment is
+        unambiguous (accuracy over coverage — see atf_parser._align_tokens).
+        """
         lines = self.fetch_all(
             """
             SELECT
+                tl.id AS line_id,
                 tl.line_number,
                 tl.raw_atf,
                 tl.is_ruling,
@@ -612,7 +621,29 @@ class ArtifactRepository(BaseRepository):
             {"p_number": p_number},
         )
 
-        return {"p_number": p_number, "lines": lines, "total_lines": len(lines)}
+        # Tokens for these lines, in position order. Only rows with a non-null
+        # raw_form are usable for surface-form alignment.
+        token_rows = self.fetch_all(
+            """
+            SELECT t.id, t.line_id, t.position, t.raw_form
+            FROM tokens t
+            JOIN text_lines tl ON t.line_id = tl.id
+            WHERE tl.p_number = %(p_number)s
+              AND t.raw_form IS NOT NULL
+            ORDER BY t.line_id, t.position
+        """,
+            {"p_number": p_number},
+        )
+        tokens_by_line: dict[int, list[dict]] = {}
+        for tr in token_rows:
+            tokens_by_line.setdefault(tr["line_id"], []).append(tr)
+
+        return {
+            "p_number": p_number,
+            "lines": lines,
+            "tokens_by_line": tokens_by_line,
+            "total_lines": len(lines),
+        }
 
     def _translation_rows(
         self,

--- a/api/routes/artifacts.py
+++ b/api/routes/artifacts.py
@@ -103,7 +103,7 @@ def get_artifact_atf(p_number: str, conn=Depends(get_db)):
         get_legend_items,
     )
 
-    parsed = parse_atf_response(atf_data["lines"])
+    parsed = parse_atf_response(atf_data["lines"], atf_data.get("tokens_by_line"))
     raw_atf = build_raw_atf(atf_data["lines"])
     legend = get_legend_items(parsed["surfaces"])
 

--- a/api/services/atf_parser.py
+++ b/api/services/atf_parser.py
@@ -70,12 +70,22 @@ _SUBSCRIPT_MAP = str.maketrans("", "", "₀₁₂₃₄₅₆₇₈₉")
 _NUMERIC_PATTERN = re.compile(r"^[\d/]+\([A-Za-z0-9_]+\)(?:[#?!]*)$")
 
 
-def parse_atf_response(lines: list[dict]) -> dict:
+def parse_atf_response(
+    lines: list[dict],
+    tokens_by_line: dict[int, list[dict]] | None = None,
+) -> dict:
     """Transform flat DB lines into structured surface/column/line format.
 
-    Input: [{line_number, raw_atf, is_ruling, is_blank, surface_type, column_number}, ...]
+    Input: [{line_id, line_number, raw_atf, is_ruling, is_blank, surface_type,
+             column_number}, ...]
+    ``tokens_by_line`` (optional): line_id -> ordered list of token rows
+        ({id, position, raw_form}). When supplied, each content word is mapped
+        to its tokens.id and emitted as ``token_id`` — but ONLY where the
+        line's words align to its tokens unambiguously (#330). See
+        ``_align_tokens`` for the refuse-on-mismatch guard.
     Output: {surfaces: [...], hasMultipleSurfaces, hasMultipleColumns}
     """
+    tokens_by_line = tokens_by_line or {}
     # Group lines by (surface_type, column_number), preserving first-appearance order
     # Key: surface_type → OrderedDict[column_number → [lines]]
     surface_columns: OrderedDict[str, OrderedDict[int, list[dict]]] = OrderedDict()
@@ -96,7 +106,11 @@ def parse_atf_response(lines: list[dict]) -> dict:
         for col_num, col_lines in col_groups.items():
             parsed_lines = []
             for db_line in col_lines:
-                parsed = _parse_db_line(db_line)
+                line_id = db_line.get("line_id")
+                line_tokens = (
+                    tokens_by_line.get(line_id) if line_id is not None else None
+                )
+                parsed = _parse_db_line(db_line, line_tokens)
                 if parsed is not None:
                     parsed_lines.append(parsed)
             columns.append(
@@ -124,8 +138,13 @@ def parse_atf_response(lines: list[dict]) -> dict:
     }
 
 
-def _parse_db_line(db_line: dict) -> dict | None:
-    """Parse a single DB row into a structured line object."""
+def _parse_db_line(db_line: dict, line_tokens: list[dict] | None = None) -> dict | None:
+    """Parse a single DB row into a structured line object.
+
+    ``line_tokens`` (optional): ordered tokens rows for this line. When given,
+    ``_align_tokens`` stamps token_id onto each content word — but only when
+    the whole line aligns unambiguously (#330).
+    """
     raw_atf = (db_line.get("raw_atf") or "").strip()
     line_number = db_line.get("line_number") or ""
     is_ruling = bool(db_line.get("is_ruling"))
@@ -165,6 +184,12 @@ def _parse_db_line(db_line: dict) -> dict | None:
 
     words = parse_words(content)
 
+    # #330: stamp tokens.id onto content words where the line aligns
+    # unambiguously. Refuses (leaves words unstamped) on any mismatch — a wrong
+    # word→token map mis-attributes a scholarly interpretation, so we never guess.
+    if line_tokens:
+        _align_tokens(words, line_tokens)
+
     return {
         "type": "content",
         "number": num_display,
@@ -174,6 +199,64 @@ def _parse_db_line(db_line: dict) -> dict | None:
         "composite": composite,
         "translations": {},
     }
+
+
+# Content word types that correspond 1:1 to a tokens row. ``broken`` blocks
+# ([x x x]) and ``punctuation`` are parser-only artifacts with no token.
+_TOKEN_WORD_TYPES = frozenset({"word", "logogram", "determinative"})
+
+# Half-bracket damage markers that ORACC strips from raw_form but the surface
+# ATF (and thus the parser) keeps. Removed before form comparison.
+_HALF_BRACKETS = str.maketrans("", "", "⸢⸣⸤⸥")  # ⸢⸣⸤⸥
+
+
+def _token_form_key(raw: str | None) -> str | None:
+    """Normalize an ATF surface form for token-alignment comparison.
+
+    Strips half-bracket damage markers, then applies the same normalization
+    used for lexical lookup (damage flags, subscripts, sign variants, case).
+    Returns None for empty/break placeholders so they never match a real word.
+    """
+    if not raw:
+        return None
+    cleaned = raw.translate(_HALF_BRACKETS)
+    key = normalize_lookup(cleaned)
+    # A bare break placeholder ('x') carries no identity — never align on it.
+    if key in (None, "x"):
+        return None
+    return key
+
+
+def _align_tokens(words: list[dict], line_tokens: list[dict]) -> None:
+    """Map each content word to its tokens.id, in order — or refuse the line.
+
+    ACCURACY OVER COVERAGE (#330). Token_id is stamped only when the line's
+    content words align 1:1 with its real tokens AND every pair's normalized
+    surface form matches. On ANY mismatch (count differs, or a form disagrees)
+    NO token_id is stamped for the line — those words stay unclickable rather
+    than risk mis-attributing an interpretation to the wrong cuneiform word.
+
+    Mutates ``words`` in place, adding ``token_id`` only on a clean alignment.
+    """
+    content_words = [w for w in words if w.get("type") in _TOKEN_WORD_TYPES]
+
+    # Real tokens: drop break-placeholder tokens (raw_form 'x'), which the
+    # parser collapses into single ``broken`` words rather than emitting per-x.
+    real_tokens = [t for t in line_tokens if _token_form_key(t.get("raw_form"))]
+
+    # Count guard: differing granularity ⇒ refuse the whole line.
+    if not content_words or len(content_words) != len(real_tokens):
+        return
+
+    # Form guard: every aligned pair's normalized form must match exactly.
+    pairs = list(zip(content_words, real_tokens))
+    for word, token in pairs:
+        if _token_form_key(word.get("text")) != _token_form_key(token.get("raw_form")):
+            return  # ambiguous alignment — refuse the entire line
+
+    # Unambiguous: stamp.
+    for word, token in pairs:
+        word["token_id"] = token["id"]
 
 
 def parse_words(text: str) -> list[dict]:

--- a/tests/unit/test_atf_token_alignment.py
+++ b/tests/unit/test_atf_token_alignment.py
@@ -1,0 +1,109 @@
+"""Unit tests for #330 word→token alignment in api.services.atf_parser.
+
+The parser stamps ``tokens.id`` onto ``.atf-word`` objects (consumed by the
+frontend interpret_token feature) — but ONLY where a line's content words align
+1:1 with its tokens AND every pair's normalized surface form matches. A wrong
+map mis-attributes a scholarly interpretation, so the guard refuses (stamps
+nothing) on any mismatch. These cases are distilled from real prod data
+(P229547 aligns cleanly; P336245 / broken lines refuse).
+"""
+
+from __future__ import annotations
+
+from api.services.atf_parser import parse_atf_response
+
+
+def _tokens(*forms: str, start_id: int = 1000, start_pos: int = 0) -> list[dict]:
+    """Build ordered token rows (id, position, raw_form)."""
+    return [
+        {"id": start_id + i, "position": start_pos + i, "raw_form": f}
+        for i, f in enumerate(forms)
+    ]
+
+
+def _words(parsed: dict) -> list[dict]:
+    """Flatten all word objects from the first content line of the response."""
+    line = parsed["surfaces"][0]["columns"][0]["lines"][0]
+    return line["words"]
+
+
+def _line(line_id: int, raw: str) -> dict:
+    return {
+        "line_id": line_id,
+        "line_number": "1",
+        "raw_atf": raw,
+        "is_ruling": False,
+        "is_blank": False,
+        "surface_type": "obverse",
+        "column_number": 1,
+    }
+
+
+def test_clean_line_aligns_and_stamps_in_order():
+    """Every content word gets the correct token_id (real-data shape)."""
+    raw = "lu₂ gub-ba mu-uh₂-hu-um"
+    tokens = {5: _tokens("lu₂", "gub-ba", "mu-uh₂-hu-um", start_id=9220371)}
+    parsed = parse_atf_response([_line(5, raw)], tokens)
+    words = [w for w in _words(parsed) if w["type"] in ("word", "logogram")]
+    assert [w["text"] for w in words] == ["lu₂", "gub-ba", "mu-uh₂-hu-um"]
+    assert [w["token_id"] for w in words] == [9220371, 9220372, 9220373]
+
+
+def test_subscript_and_case_normalization_still_aligns():
+    """za-ab-bu-u₂ (word) vs za-ab-bu-u₂ (token), SAL logogram vs SAL token."""
+    raw = "⸢SAL⸣ lu₂-ni₂-su-ub-ba za-ba-a-tum"
+    tokens = {7: _tokens("SAL", "lu₂-ni₂-su-ub-ba", "za-ba-a-tum", start_id=200)}
+    parsed = parse_atf_response([_line(7, raw)], tokens)
+    words = [w for w in _words(parsed) if w["type"] in ("word", "logogram")]
+    assert [w.get("token_id") for w in words] == [200, 201, 202]
+
+
+def test_break_placeholder_tokens_are_ignored_when_counting():
+    """ORACC 'x' break tokens are dropped; parser collapses [x x x] to one word.
+
+    The single ``broken`` word carries no token_id, and the real words align.
+    """
+    raw = "[x x x] a-di AGA"
+    # ORACC emits per-x break tokens plus the two real words.
+    tokens = {
+        9: [
+            {"id": 1, "position": 0, "raw_form": "x"},
+            {"id": 2, "position": 1, "raw_form": "x"},
+            {"id": 3, "position": 2, "raw_form": "x"},
+            {"id": 50, "position": 31, "raw_form": "a-di"},
+            {"id": 51, "position": 32, "raw_form": "AGA"},
+        ]
+    }
+    parsed = parse_atf_response([_line(9, raw)], tokens)
+    words = _words(parsed)
+    broken = [w for w in words if w["type"] == "broken"]
+    real = [w for w in words if w["type"] in ("word", "logogram")]
+    assert broken and "token_id" not in broken[0]
+    assert [w.get("token_id") for w in real] == [50, 51]
+
+
+def test_count_mismatch_refuses_whole_line():
+    """Parser yields more content words than real tokens ⇒ stamp nothing."""
+    # Determinative split: parser sees {d} + EN as a determinative word; if the
+    # token stream collapses differently the counts diverge → refuse.
+    raw = "a-di AGA {d}EN extra-word"
+    tokens = {11: _tokens("a-di", "AGA", "{d}EN", start_id=300)}  # 3 tokens, 4 words
+    parsed = parse_atf_response([_line(11, raw)], tokens)
+    for w in _words(parsed):
+        assert "token_id" not in w, f"mis-mapped on count mismatch: {w}"
+
+
+def test_form_mismatch_refuses_whole_line():
+    """Counts match but a form disagrees ([i]-na→-na vs i-na) ⇒ stamp nothing."""
+    raw = "[i]-na UGU"  # parser yields '-na' for the broken-bracket word
+    tokens = {13: _tokens("i-na", "UGU", start_id=400)}
+    parsed = parse_atf_response([_line(13, raw)], tokens)
+    for w in _words(parsed):
+        assert "token_id" not in w, f"mis-mapped on form mismatch: {w}"
+
+
+def test_no_tokens_supplied_leaves_words_unstamped():
+    """Backwards compatible: payloads predating the join carry no token_id."""
+    parsed = parse_atf_response([_line(1, "lu₂ gub-ba")], None)
+    for w in _words(parsed):
+        assert "token_id" not in w


### PR DESCRIPTION
## What
Stamps `tokens.id` onto `/atf` `.atf-word` objects so the already-shipped-but-inert `interpret_token` frontend activates (#330).

- `get_atf` now carries `text_lines.id` (line_id) and returns `tokens_by_line` (id, position, raw_form).
- `atf_parser._align_tokens` maps content words → tokens by **normalized surface-form match, in order**.

## Accuracy over coverage (the load-bearing guarantee)
A wrong word→token map mis-attributes a scholarly interpretation to the wrong cuneiform word. The guard **refuses the whole line** (stamps nothing) on ANY mismatch:
- count differs (parser collapses `[x x x]` breaks; ORACC emits per-`x` tokens), or
- any pair's normalized form disagrees (`[i]-na` → `-na` vs token `i-na`).

Half-bracket damage (`⸢⸣`) is stripped before comparison so clean lines align; broken lines correctly skip.

## Proof on real prod data
| Tablet | Words stamped | Lines | Incorrect |
|---|---|---|---|
| P229547 | 2716 | 693 | **0** |
| P336245 (heavily broken) | 0 | 0 | **0** (refuses all 576) |
| P282609 | 128 | 40 | **0** |

Every stamped token_id's `raw_form` normalizes exactly to its word. Live interpret on a stamped word (`be-li2`, P358871/8012432) returns a grounded chain (4 steps + hypotheses).

## Frontend
No change needed — `atf-viewer.renderWords` already reads `word.token_id` and emits `data-token-id`.

## Gate
ruff ✓ · mypy ✓ (38 files) · pytest 125 passed (6 new alignment tests, incl. count- and form-mismatch refusal).

## Known follow-up (not this PR)
`core/agent/fact_assembly.assemble_token_facts` INNER-JOINs `surfaces` and filters `s.p_number`; ~264k tokenized `text_lines` rows have `surface_id = NULL`, so stamped tokens on those lines return "Token not found" from interpret. Fix is to resolve p_number via `text_lines.p_number` directly. Filed separately — out of this slice's file ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)