### PR TITLE
#404: artifact↔composite link — witness-switcher + sibling strip (A+B)

### DIFF
--- a/api/repositories/artifact_repo.py
+++ b/api/repositories/artifact_repo.py
@@ -525,10 +525,17 @@ class ArtifactRepository(BaseRepository):
         return row["wikidata_qid"] if row else None
 
     def get_composites(self, p_number: str) -> list[dict]:
+        """Compositions this tablet witnesses.
+
+        ``line_ref`` is this tablet's coverage range within the composition
+        (e.g. "obv 1–40"), a free-text whole-tablet range from
+        ``artifact_composites`` — surfaced as the "covers" chip on the tablet
+        page (#404 Concept B). NULL when not recorded (no chip shown).
+        """
         return self.fetch_all(
             """
             SELECT c.q_number, c.designation, c.language, c.period,
-                   c.genre, c.exemplar_count
+                   c.genre, c.exemplar_count, ac.line_ref
             FROM composites c
             JOIN artifact_composites ac ON c.q_number = ac.q_number
             WHERE ac.p_number = %(p_number)s

--- a/api/repositories/composite_repo.py
+++ b/api/repositories/composite_repo.py
@@ -71,10 +71,16 @@ class CompositeRepository(BaseRepository):
             q_number: The composite Q-number
 
         Returns:
-            List of artifact dictionaries that are exemplars of this composite
+            List of artifact dictionaries that are exemplars of this composite.
+            Each row carries ``atf_line_count`` — the number of *readable* ATF
+            lines (same non-structural filter as the representative-preview
+            query: excludes ``$``/``@``/``&``/``#`` lines). This powers the
+            "Extent" column (#404 Concept A): how complete each witness is, from
+            data we hold rather than a self-reported field. Witnesses with no
+            readable ATF report ``0``.
         """
         return self.fetch_all(
-            """
+            r"""
             SELECT
                 a.p_number,
                 a.designation,
@@ -83,7 +89,15 @@ class CompositeRepository(BaseRepository):
                 a.genre,
                 ac.line_ref,
                 ps.semantic_complete,
-                ps.has_translation
+                ps.has_translation,
+                COALESCE((
+                    SELECT count(*)
+                    FROM text_lines tl
+                    WHERE tl.p_number = a.p_number
+                      AND tl.raw_atf IS NOT NULL
+                      AND tl.raw_atf <> ''
+                      AND tl.raw_atf !~ '^[$@&#]'
+                ), 0) AS atf_line_count
             FROM artifacts a
             JOIN artifact_composites ac ON a.p_number = ac.p_number
             LEFT JOIN pipeline_status ps ON a.p_number = ps.p_number
@@ -92,6 +106,64 @@ class CompositeRepository(BaseRepository):
         """,
             {"q_number": q_number},
         )
+
+    def get_witness_atf_preview(
+        self, q_number: str, p_number: str, limit: int = 8
+    ) -> dict | None:
+        """First-N readable ATF lines of *one specific* witness (#404 Concept A).
+
+        Generalises ``get_representative_atf_preview`` to any exemplar so the
+        witness-switcher can read any witness's text in place, not just the one
+        representative. Verifies ``p_number`` is actually linked to ``q_number``
+        first (no cross-composite leakage). Same readable-line filter; ``raw_atf``
+        returned verbatim. Returns ``None`` when the witness is not linked or has
+        no readable ATF, so the caller keeps the current preview unchanged.
+        """
+        rep = self.fetch_one(
+            r"""
+            SELECT a.p_number,
+                   a.designation,
+                   a.period,
+                   a.provenience,
+                   count(tl.id) AS atf_line_count
+            FROM artifact_composites ac
+            JOIN artifacts a ON a.p_number = ac.p_number
+            JOIN text_lines tl ON tl.p_number = ac.p_number
+            WHERE ac.q_number = %(q_number)s
+              AND ac.p_number = %(p_number)s
+              AND tl.raw_atf IS NOT NULL
+              AND tl.raw_atf <> ''
+              AND tl.raw_atf !~ '^[$@&#]'
+            GROUP BY a.p_number, a.designation, a.period, a.provenience
+            """,
+            {"q_number": q_number, "p_number": p_number},
+        )
+        if not rep:
+            return None
+
+        lines = self.fetch_all(
+            r"""
+            SELECT tl.line_number, tl.raw_atf
+            FROM text_lines tl
+            WHERE tl.p_number = %(p_number)s
+              AND tl.raw_atf IS NOT NULL
+              AND tl.raw_atf <> ''
+              AND tl.raw_atf !~ '^[$@&#]'
+            ORDER BY tl.column_number, tl.id
+            LIMIT %(limit)s
+            """,
+            {"p_number": rep["p_number"], "limit": limit},
+        )
+
+        return {
+            "p_number": rep["p_number"],
+            "designation": rep["designation"],
+            "period": rep["period"],
+            "provenience": rep["provenience"],
+            "total_atf_lines": rep["atf_line_count"],
+            "preview_line_count": len(lines),
+            "lines": lines,
+        }
 
     def get_representative_atf_preview(
         self, q_number: str, limit: int = 8

--- a/api/routes/composites.py
+++ b/api/routes/composites.py
@@ -113,3 +113,30 @@ def get_composite_exemplars(q_number: str, conn=Depends(get_db)):
     exemplars = repo.get_exemplars(q_number)
 
     return {"q_number": q_number, "exemplars": exemplars, "count": len(exemplars)}
+
+
+@router.get("/{q_number}/witnesses/{p_number}/atf-preview")
+def get_composite_witness_atf_preview(
+    q_number: str,
+    p_number: str,
+    limit: int = Query(8, ge=1, le=40, description="Lines to preview"),
+    conn=Depends(get_db),
+):
+    """First-N readable ATF lines of one specific witness (#404 Concept A).
+
+    Backs the witness-switcher: clicking a witness chip on the composition page
+    fetches *that* witness's text in place. ``atf_preview`` is ``null`` when the
+    witness is not linked to this composite or carries no readable ATF (the
+    client keeps the current preview); 404 only for an unknown Q-number.
+    """
+    repo = CompositeRepository(conn)
+
+    composite = repo.find_by_q_number(q_number)
+    if not composite:
+        raise HTTPException(status_code=404, detail=f"Composite {q_number} not found")
+
+    return {
+        "q_number": q_number,
+        "p_number": p_number,
+        "atf_preview": repo.get_witness_atf_preview(q_number, p_number, limit=limit),
+    }

--- a/app/routes/compositions.py
+++ b/app/routes/compositions.py
@@ -151,6 +151,28 @@ def composition_detail(
 
     filtered = [{**e, "coverage": _coverage(e)} for e in filtered]
 
+    # #404 Concept A — witness-switcher + extent column.
+    # `extent_max` = the most readable ATF lines any single witness holds; the
+    # extent bar in the exemplars table is each witness's count / this max, so
+    # "which witness is most complete?" reads straight off the table. Computed
+    # over ALL exemplars (not the filtered view) so the bar's scale stays stable
+    # while a scholar filters by site/period.
+    extent_max = max((e.get("atf_line_count") or 0 for e in all_exemplars), default=0)
+
+    # Witnesses readable in the switcher: those carrying readable ATF, best-
+    # preserved first (strongest comparanda surface first — spec default). The
+    # representative witness (matches the pre-loaded preview) is starred and
+    # pre-selected. A single readable witness renders one non-interactive chip.
+    rep_p = (atf_preview or {}).get("p_number")
+    witnesses = sorted(
+        (
+            {**e, "coverage": _coverage(e)}
+            for e in all_exemplars
+            if (e.get("atf_line_count") or 0) > 0
+        ),
+        key=lambda e: (-(e.get("atf_line_count") or 0), e.get("p_number") or ""),
+    )
+
     # Build transmission history: group exemplars by period for the old row-based
     # timeline (kept for fallback; SVG timeline uses raw exemplars client-side)
     timeline: dict[str, list[dict]] = {}
@@ -212,6 +234,9 @@ def composition_detail(
             "composite": composite_meta,
             "exemplars": filtered,
             "atf_preview": atf_preview,
+            "witnesses": witnesses,
+            "extent_max": extent_max,
+            "rep_p": rep_p,
             "timeline_exemplars": timeline_exemplars,
             "linked_count": linked_count,
             "oracc_count": oracc_count,

--- a/app/static/css/pages/compositions.css
+++ b/app/static/css/pages/compositions.css
@@ -802,3 +802,107 @@
 .breadcrumb a:hover {
     text-decoration: underline;
 }
+
+/* ==========================================================================
+   #404 Concept A — witness-switcher + extent column on the composite preview.
+   Token-driven only. Lets a scholar read any witness's ATF in place, and the
+   "Extent" column answers "which witness is most complete?" as data-ink.
+   ========================================================================== */
+.witness-switcher {
+    display: flex;
+    gap: var(--space-2);
+    overflow-x: auto;
+    padding-bottom: var(--space-2);
+    margin-bottom: var(--space-4);
+    scrollbar-width: thin;
+}
+.witness-chip {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 132px;
+    padding: var(--space-2) var(--space-3);
+    background: var(--surface-raised);
+    border: var(--border-subtle);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    text-align: left;
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
+}
+.witness-chip:hover {
+    border: var(--border-default);
+    box-shadow: var(--elevation-1);
+}
+.witness-chip.is-active {
+    border: var(--border-strong);
+    background: var(--color-accent-10);
+    box-shadow: var(--elevation-1);
+}
+.witness-chip[disabled],
+.witness-chip--static {
+    cursor: default;
+}
+.witness-chip__top {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+}
+.witness-chip__cov {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--color-border);
+}
+.witness-chip__cov--translated  { background: var(--color-success); }
+.witness-chip__cov--partial     { background: var(--color-warning); }
+.witness-chip__cov--untranslated{ background: var(--color-text-subtle); }
+.witness-chip__pnum {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text);
+    font-weight: var(--font-weight-medium);
+}
+.witness-chip.is-active .witness-chip__pnum { color: var(--color-accent); }
+.witness-chip__meta {
+    font-size: var(--text-xxs);
+    color: var(--color-text-subtle);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
+}
+.witness-chip__lines {
+    font-size: var(--text-xxs);
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.witness-chip--rep .witness-chip__pnum::after {
+    content: "★";
+    margin-left: var(--space-1);
+    color: var(--color-accent);
+    font-size: var(--text-xxs);
+}
+
+/* extent bar reused inside the exemplars table ("how complete?") */
+.extent-cell { display: flex; align-items: center; gap: var(--space-2); min-width: 0; }
+.extent-bar {
+    flex: 1 1 auto;
+    height: 4px;
+    min-width: 40px;
+    background: var(--color-overlay-light);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+}
+.extent-bar__fill {
+    height: 100%;
+    background: var(--color-accent-muted);
+    border-radius: var(--radius-full);
+}
+.extent-num {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}

--- a/app/static/css/pages/tablets.css
+++ b/app/static/css/pages/tablets.css
@@ -1811,3 +1811,75 @@ body.page-tablet-detail > .page-header {
     flex-direction: column;
     min-height: 0;
 }
+
+/* ==========================================================================
+   #404 Concept B — sibling-witness strip + coverage chip on the tablet page.
+   Finishes the composite-panel reverse link (the old "Loading tablets…"
+   placeholder): hop directly to a neighbouring copy, and see this tablet's
+   coverage range within the text. Token-driven only.
+   ========================================================================== */
+.witness-siblings { margin-top: var(--space-3); }
+.witness-siblings__label {
+    font-size: var(--text-2xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-subtle);
+    margin: 0 0 var(--space-2);
+}
+.witness-siblings__strip {
+    display: flex;
+    gap: var(--space-2);
+    overflow-x: auto;
+    padding-bottom: var(--space-2);
+    scrollbar-width: thin;
+}
+.sibling-card {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 120px;
+    padding: var(--space-2) var(--space-3);
+    background: var(--surface-raised);
+    border: var(--border-subtle);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+.sibling-card:hover { border: var(--border-default); box-shadow: var(--elevation-1); }
+.sibling-card.is-current {
+    border: var(--border-strong);
+    background: var(--color-accent-10);
+    cursor: default;
+}
+.sibling-card__top { display: flex; align-items: center; gap: var(--space-1-5); }
+.sibling-card__pnum { font-family: var(--font-mono); font-size: var(--text-xs); font-weight: var(--font-weight-medium); }
+.sibling-card.is-current .sibling-card__pnum { color: var(--color-accent); }
+.sibling-card__period { font-size: var(--text-xxs); color: var(--color-text-subtle); }
+.sibling-card__ref { font-size: var(--text-xxs); color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+.sibling-card__cov {
+    width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: var(--color-border);
+}
+.sibling-card__cov--translated  { background: var(--color-success); }
+.sibling-card__cov--partial     { background: var(--color-warning); }
+.sibling-card__cov--untranslated{ background: var(--color-text-subtle); }
+.sibling-card--more {
+    align-items: center; justify-content: center;
+    color: var(--color-accent); font-size: var(--text-xs); min-width: 96px;
+}
+.sibling-card__sk {
+    height: 11px; background: var(--color-overlay-light); border-radius: var(--radius-xs);
+}
+.sibling-card__sk--sm { height: 9px; width: 80%; margin-top: 6px; }
+.covers-chip {
+    display: inline-flex; align-items: center; gap: var(--space-1);
+    padding: 2px var(--space-2);
+    background: var(--color-accent-10);
+    border: 1px solid var(--color-accent-20);
+    border-radius: var(--radius-full);
+    font-size: var(--text-2xs);
+    color: var(--color-accent);
+    font-variant-numeric: tabular-nums;
+}
+.covers-note { font-size: var(--text-xs); color: var(--color-text-subtle); margin-left: var(--space-2); }

--- a/app/static/js/tablet-detail.js
+++ b/app/static/js/tablet-detail.js
@@ -247,14 +247,43 @@ function loadSignAnnotations() {
         });
 }
 
-// Load composite tablets from API
+// #404 Concept B — sibling-witness strip.
+// On panel-open, fetch the composite's exemplars and render the OTHER tablets
+// witnessing the same text as a horizontal strip of navigable cards (the current
+// tablet highlighted, non-link). Best-preserved siblings first; capped to 8 with
+// a "+N more" card → the composition page. Coverage dot maps translation status.
+const SIBLING_CAP = 8;
+
+function htmlEscape(s) {
+    const d = document.createElement('div');
+    d.textContent = s == null ? '' : String(s);
+    return d.innerHTML;
+}
+
+function siblingCoverage(t) {
+    // Mirror the composition route's _coverage(): semantic_complete is canonical
+    // (binary today), has_translation the fallback.
+    let score;
+    const raw = t.semantic_complete;
+    if (raw != null && raw !== '' && !isNaN(parseFloat(raw))) {
+        score = parseFloat(raw);
+    } else {
+        score = t.has_translation ? 1 : 0;
+    }
+    if (score >= 0.99) return 'translated';
+    if (score > 0) return 'partial';
+    return 'untranslated';
+}
+
 function loadCompositeTablets(qNumber) {
     if (!qNumber || !TabletPage.apiUrl) return;
 
+    const wrap = document.getElementById('composite-siblings');
     const listContainer = document.getElementById('composite-list');
     const countBadge = document.getElementById('composite-count');
+    const label = wrap ? wrap.querySelector('.witness-siblings__label') : null;
+    if (!listContainer) return;
 
-    // Use correct endpoint for composite exemplars
     fetch(`${TabletPage.apiUrl}/composites/${qNumber}/exemplars`)
         .then(response => {
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -263,41 +292,66 @@ function loadCompositeTablets(qNumber) {
         .then(data => {
             const exemplars = data.exemplars || [];
 
-            if (exemplars.length === 0) {
-                listContainer.innerHTML = '<div class="composite-panel__loading">No tablets</div>';
+            if (countBadge) {
+                countBadge.textContent =
+                    `${exemplars.length} witness${exemplars.length !== 1 ? 'es' : ''} in Glintstone`;
+            }
+
+            // Only witness linked: collapse the strip to a single statement.
+            if (exemplars.length <= 1) {
+                if (label) {
+                    label.textContent =
+                        'This is the only witness of this text linked in Glintstone.';
+                }
+                listContainer.remove();
                 return;
             }
 
-            // Render actual tablet items with thumbnails
-            listContainer.innerHTML = exemplars.map(tablet => {
-                const isCurrent = tablet.p_number === TabletPage.pNumber;
-                const thumbUrl = `${TabletPage.apiUrl}/image/${tablet.p_number}?size=64`;
+            // Best-preserved siblings first (most readable ATF lines) — the
+            // strongest comparanda surface first (spec default).
+            const sorted = exemplars.slice().sort(
+                (a, b) => (b.atf_line_count || 0) - (a.atf_line_count || 0)
+            );
 
-                return `
-                    <a href="/tablets/${tablet.p_number}"
-                       class="composite-tablet-item ${isCurrent ? 'is-current' : ''}"
-                       data-p-number="${tablet.p_number}">
-                        <div class="composite-tablet-item__thumbnail">
-                            <img src="${thumbUrl}"
-                                 alt="${tablet.designation || tablet.p_number}"
-                                 loading="lazy"
-                                 onerror="this.style.display='none';">
-                        </div>
-                        <div class="composite-tablet-item__info">
-                            <div class="composite-tablet-item__pnumber">${tablet.p_number}</div>
-                            <div class="composite-tablet-item__designation">${tablet.designation || 'Unnamed'}</div>
-                        </div>
-                    </a>
-                `;
-            }).join('');
+            // Current tablet first (highlighted), then capped siblings.
+            const current = sorted.filter(t => t.p_number === TabletPage.pNumber);
+            const others = sorted.filter(t => t.p_number !== TabletPage.pNumber);
+            const shown = current.concat(others.slice(0, SIBLING_CAP));
+            const overflow = others.length - Math.min(others.length, SIBLING_CAP);
 
-            // Update count badge
-            if (countBadge) {
-                countBadge.textContent = `${exemplars.length} tablet${exemplars.length !== 1 ? 's' : ''}`;
+            const cards = shown.map(t => {
+                const isCurrent = t.p_number === TabletPage.pNumber;
+                const cov = siblingCoverage(t);
+                const period = t.period || 'Period unknown';
+                const prov = t.provenience ? ` · ${htmlEscape(t.provenience)}` : '';
+                const ref = isCurrent
+                    ? (t.line_ref ? `this tablet · ${htmlEscape(t.line_ref)}` : 'this tablet')
+                    : (t.line_ref ? htmlEscape(t.line_ref) : '');
+                const inner =
+                    `<span class="sibling-card__top">` +
+                    `<span class="sibling-card__cov sibling-card__cov--${cov}"></span>` +
+                    `<span class="sibling-card__pnum">${htmlEscape(t.p_number)}</span></span>` +
+                    `<span class="sibling-card__period">${htmlEscape(period)}${prov}</span>` +
+                    (ref ? `<span class="sibling-card__ref">${ref}</span>` : '');
+                return isCurrent
+                    ? `<div class="sibling-card is-current">${inner}</div>`
+                    : `<a class="sibling-card" href="/tablets/${htmlEscape(t.p_number)}">${inner}</a>`;
+            });
+
+            if (overflow > 0) {
+                cards.push(
+                    `<a class="sibling-card sibling-card--more" ` +
+                    `href="/compositions/${htmlEscape(qNumber)}">+ ${overflow} more ›</a>`
+                );
             }
+
+            listContainer.innerHTML = cards.join('');
+            listContainer.setAttribute('aria-busy', 'false');
         })
         .catch(err => {
-            console.error('Composite load failed:', err);
-            listContainer.innerHTML = '<div class="composite-panel__loading">Failed to load</div>';
+            console.error('Composite siblings load failed:', err);
+            listContainer.innerHTML =
+                '<div class="composite-panel__loading">Failed to load other witnesses</div>';
+            listContainer.setAttribute('aria-busy', 'false');
         });
 }

--- a/app/static/js/witness-switcher.js
+++ b/app/static/js/witness-switcher.js
@@ -1,0 +1,125 @@
+/**
+ * Witness-switcher (#404 Concept A).
+ *
+ * On a composition detail page, the ATF preview opens on the representative
+ * witness. Clicking a witness chip fetches that witness's first-N readable ATF
+ * lines and swaps the preview block in place — read any witness, no page load.
+ * No cross-witness line alignment is claimed; each chip is one witness read
+ * end-to-end. Degrades silently when the switcher isn't present (empty/single).
+ */
+(function () {
+    'use strict';
+
+    var switcher = document.getElementById('witness-switcher');
+    var section = document.querySelector('.composition-detail__atf-preview');
+    if (!switcher || !section) return;
+
+    var chips = Array.prototype.slice.call(
+        switcher.querySelectorAll('.witness-chip')
+    );
+    // Single non-interactive witness: nothing to switch.
+    if (chips.length <= 1) return;
+
+    var qNumber = section.dataset.qNumber;
+    var apiUrl = section.dataset.apiUrl;
+    if (!qNumber || !apiUrl) return;
+
+    var list = document.getElementById('witness-atf-list');
+    var hint = document.getElementById('atf-preview-hint');
+    var count = document.getElementById('atf-preview-count');
+    var fullLink = document.getElementById('atf-preview-full');
+
+    // Cache fetched witnesses so re-clicking a chip is instant.
+    var cache = {};
+
+    function esc(s) {
+        var d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
+
+    function setActive(chip) {
+        chips.forEach(function (c) {
+            var on = c === chip;
+            c.classList.toggle('is-active', on);
+            c.setAttribute('aria-selected', on ? 'true' : 'false');
+        });
+    }
+
+    function renderPreview(p, data) {
+        var lines = (data && data.lines) || [];
+        if (!lines.length) return; // keep current preview; never blank it
+
+        list.innerHTML = lines.map(function (line) {
+            var ref = line.line_number ? 'l. ' + esc(line.line_number) : '—';
+            return (
+                '<li class="attestation-row">' +
+                '<a class="attestation-row__link" href="/tablets/' + esc(p) + '">' +
+                '<span class="attestation-row__ref">' +
+                '<span class="attestation-row__line">' + ref + '</span></span>' +
+                '<span class="attestation-row__main">' +
+                '<span class="attestation-row__atf" lang="akk" dir="ltr">' +
+                esc(line.raw_atf) + '</span></span></a></li>'
+            );
+        }).join('');
+
+        if (count && data.total_atf_lines != null) {
+            var n = data.total_atf_lines;
+            count.textContent =
+                'First ' + data.preview_line_count + ' of ' +
+                n.toLocaleString() + ' line' + (n === 1 ? '' : 's');
+        }
+        if (fullLink) fullLink.href = '/tablets/' + p;
+    }
+
+    function setHint(chip, data) {
+        if (!hint) return;
+        var p = chip.dataset.pNumber;
+        var desig = chip.dataset.designation || p;
+        var period = chip.dataset.period;
+        var prov = chip.dataset.provenience;
+        var tail = (period ? ', ' + esc(period) : '') +
+            (prov ? ' (' + esc(prov) + ')' : '');
+        hint.innerHTML =
+            'Reading <a href="/tablets/' + esc(p) + '">' + esc(desig) + '</a>' +
+            tail + '.';
+    }
+
+    function select(chip) {
+        var p = chip.dataset.pNumber;
+        setActive(chip);
+        setHint(chip, null);
+
+        if (cache[p]) {
+            renderPreview(p, cache[p]);
+            return;
+        }
+
+        list.setAttribute('aria-busy', 'true');
+        fetch(apiUrl + '/composites/' + encodeURIComponent(qNumber) +
+              '/witnesses/' + encodeURIComponent(p) + '/atf-preview')
+            .then(function (r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                return r.json();
+            })
+            .then(function (resp) {
+                var data = resp && resp.atf_preview;
+                if (data) {
+                    cache[p] = data;
+                    renderPreview(p, data);
+                }
+            })
+            .catch(function (err) {
+                console.error('Witness preview load failed:', err);
+            })
+            .finally(function () {
+                list.setAttribute('aria-busy', 'false');
+            });
+    }
+
+    chips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+            if (!chip.classList.contains('is-active')) select(chip);
+        });
+    });
+}());

--- a/app/templates/compositions/detail.html
+++ b/app/templates/compositions/detail.html
@@ -101,11 +101,12 @@
          attestation rendering: ``raw_atf`` shown verbatim (prime notation and
          damage brackets preserved). ``atf_preview`` is null when no linked
          exemplar has readable ATF → #189 empty state. ──────────────────────── #}
-    <section class="composition-detail__atf-preview" aria-labelledby="atf-preview-heading">
+    <section class="composition-detail__atf-preview" aria-labelledby="atf-preview-heading"
+             {% if atf_preview and atf_preview.lines %}data-q-number="{{ composite.q_number }}" data-api-url="{{ api_url }}"{% endif %}>
         <div class="composition-detail__atf-preview-header">
             <h2 id="atf-preview-heading">Transliteration preview</h2>
             {% if atf_preview and atf_preview.lines %}
-            <span class="composition-detail__atf-preview-count">
+            <span class="composition-detail__atf-preview-count" id="atf-preview-count">
                 First {{ atf_preview.preview_line_count }} of
                 {{ "{:,}".format(atf_preview.total_atf_lines) }} line{{ '' if atf_preview.total_atf_lines == 1 else 's' }}
             </span>
@@ -113,11 +114,35 @@
         </div>
 
         {% if atf_preview and atf_preview.lines %}
-        <p class="composition-detail__atf-preview-hint">
+        {# #404 Concept A — witness-switcher. Read any witness's ATF in place.
+           Best-preserved first; ★ = representative (pre-selected). A single
+           readable witness renders one non-interactive chip (no false compare). #}
+        {% set single_witness = witnesses | length <= 1 %}
+        <div class="witness-switcher" id="witness-switcher" role="tablist" aria-label="Choose a witness to read">
+            {% for w in witnesses %}
+            {% set is_rep = w.p_number == rep_p %}
+            <button class="witness-chip{% if is_rep %} witness-chip--rep is-active{% endif %}{% if single_witness %} witness-chip--static{% endif %}"
+                    role="tab" aria-selected="{{ 'true' if is_rep else 'false' }}"
+                    data-p-number="{{ w.p_number }}"
+                    data-designation="{{ w.designation or '' }}"
+                    data-period="{{ w.period or '' }}"
+                    data-provenience="{{ w.provenience or '' }}"
+                    {% if single_witness %}aria-disabled="true"{% endif %}>
+                <span class="witness-chip__top">
+                    <span class="witness-chip__cov witness-chip__cov--{{ w.coverage or 'untranslated' }}"></span>
+                    <span class="witness-chip__pnum">{{ w.p_number }}</span>
+                </span>
+                <span class="witness-chip__meta">{{ w.period or 'Period unknown' }}{% if w.provenience %} · {{ w.provenience }}{% endif %}</span>
+                <span class="witness-chip__lines">{{ "{:,}".format(w.atf_line_count) }} lines{% if single_witness %} · only witness with text{% endif %}</span>
+            </button>
+            {% endfor %}
+        </div>
+
+        <p class="composition-detail__atf-preview-hint" id="atf-preview-hint">
             Transliterated text of a representative exemplar —
             <a href="/tablets/{{ atf_preview.p_number }}">{{ atf_preview.designation or atf_preview.p_number }}</a>{% if atf_preview.period %}, {{ atf_preview.period }}{% endif %}{% if atf_preview.provenience %} ({{ atf_preview.provenience }}){% endif %}.
         </p>
-        <ul class="attestation-list">
+        <ul class="attestation-list" id="witness-atf-list" aria-busy="false">
             {% for line in atf_preview.lines %}
             <li class="attestation-row">
                 <a class="attestation-row__link" href="/tablets/{{ atf_preview.p_number }}">
@@ -132,7 +157,7 @@
             {% endfor %}
         </ul>
         <div class="composition-detail__atf-preview-footer">
-            <a class="composition-detail__atf-preview-full" href="/tablets/{{ atf_preview.p_number }}">
+            <a class="composition-detail__atf-preview-full" id="atf-preview-full" href="/tablets/{{ atf_preview.p_number }}">
                 Read the full tablet ›
             </a>
         </div>
@@ -182,6 +207,7 @@
                     <th>Designation</th>
                     <th>Period</th>
                     <th>Provenience</th>
+                    <th>Extent</th>
                     <th>Coverage</th>
                 </tr>
             </thead>
@@ -198,6 +224,20 @@
                     <td>{{ ex.designation or '—' }}</td>
                     <td>{{ ex.period or '—' }}</td>
                     <td>{{ ex.provenience or '—' }}</td>
+                    <td>
+                        {# #404 Concept A — extent bar: readable ATF lines we hold,
+                           scaled to the most-complete witness. Answers "which
+                           witness is most complete?" in the table as data-ink. #}
+                        {% set ext = ex.atf_line_count or 0 %}
+                        {% if ext > 0 and extent_max > 0 %}
+                        <span class="extent-cell">
+                            <span class="extent-bar"><span class="extent-bar__fill" style="width: {{ (ext * 100 // extent_max) }}%"></span></span>
+                            <span class="extent-num">{{ "{:,}".format(ext) }}</span>
+                        </span>
+                        {% else %}
+                        <span class="extent-num">—</span>
+                        {% endif %}
+                    </td>
                     <td>
                         <span class="badge badge--coverage-{{ cov }}">{{ coverage_labels[cov] }}</span>
                     </td>
@@ -289,4 +329,5 @@
 }());
 </script>
 {% endif %}
+<script src="/static/js/witness-switcher.js?v={{ app_version }}"></script>
 {% endblock %}

--- a/app/templates/tablets/detail.html
+++ b/app/templates/tablets/detail.html
@@ -46,8 +46,26 @@
             {% endfor %}
         </div>
         {% else %}
-        <div class="composite-panel__list" id="composite-list">
-            <div class="composite-panel__loading">Loading tablets...</div>
+        {# #404 Concept B — this tablet's coverage range within the text. From
+           artifact_composites.line_ref (a free-text whole-tablet range, e.g.
+           "obv 1–40"); shown only when recorded. #}
+        {% if primary.line_ref %}
+        <div class="composite-panel__covers">
+            <span class="covers-chip">covers {{ primary.line_ref }}</span>
+        </div>
+        {% endif %}
+
+        {# #404 Concept B — sibling-witness strip. The other tablets witnessing
+           this text, reachable directly. tablet-detail.js fills this list from
+           the composite's exemplars on panel-open; skeletons hold the space. #}
+        <div class="witness-siblings" id="composite-siblings"
+             data-q-number="{{ primary.q_number }}" data-p-number="{{ tablet.p_number }}">
+            <p class="witness-siblings__label">Other witnesses of this text</p>
+            <div class="witness-siblings__strip" id="composite-list" aria-busy="true">
+                <div class="sibling-card"><div class="sibling-card__sk" style="width:60%;"></div><div class="sibling-card__sk sibling-card__sk--sm"></div></div>
+                <div class="sibling-card"><div class="sibling-card__sk" style="width:55%;"></div><div class="sibling-card__sk sibling-card__sk--sm"></div></div>
+                <div class="sibling-card"><div class="sibling-card__sk" style="width:62%;"></div><div class="sibling-card__sk sibling-card__sk--sm" style="width:70%;"></div></div>
+            </div>
         </div>
         <a class="composite-panel__view-all" href="/compositions/{{ primary.q_number }}">
             View all{% if primary.exemplar_count %} {{ "{:,}".format(primary.exemplar_count) }}{% endif %} exemplars


### PR DESCRIPTION
Builds the render-proven spec at `PERSONAL/design/specs/artifact-composite-link/` (Concepts A + B; C deferred per #316).

## Concept A — composition detail (witness-switcher + extent)
- Read **any** witness's ATF in place via a tablist of witness chips (★ = representative, pre-loaded; lazy-fetch on click). New endpoint `/composites/{q}/witnesses/{p}/atf-preview`.
- New **Extent** column on the exemplars table: a proportional bar (readable ATF lines / most-complete witness) + raw count — answers "which witness is most complete?" as data-ink.

## Concept B — tablet detail (sibling strip + coverage)
- The old `Loading tablets…` placeholder becomes a **sibling-witness strip** (best-preserved first, current tablet highlighted, capped at 8 + "+N more"). Only-witness collapses to a statement.
- **`covers ll. X–Y`** chip from `artifact_composites.line_ref`.

## Notes
- No schema change. Token-driven CSS only (no raw hex). Reuses `.attestation-row`, `badge--coverage-*`, `.composite-panel`, `data_empty`.
- Gate: ruff + mypy clean; 346 passed / 40 skipped (DB-less). Render-verified against the prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaVPgcKSmgDDwvBnKU4Je1