### PR TITLE
Corpus Atlas Wave 1: timeline + find-spots linked filter (#320)

### DIFF
--- a/api/repositories/artifact_repo.py
+++ b/api/repositories/artifact_repo.py
@@ -299,6 +299,198 @@ class ArtifactRepository(BaseRepository):
 
     # ── Search with multi-select ────────────────────────────
 
+    def _build_search_where(
+        self,
+        search: str | None = None,
+        pipeline: str | None = None,
+        period: list[str] | None = None,
+        provenience: list[str] | None = None,
+        genre: list[str] | None = None,
+        language: list[str] | None = None,
+        has_ocr: bool = False,
+    ) -> tuple[list[str], dict]:
+        """Build the WHERE conditions + params shared by search() and the
+        Corpus-Atlas aggregate queries (timeline / by-site).
+
+        Returns (conditions, params). The conditions assume the FROM clause
+        aliases ``artifacts`` as ``a`` and LEFT JOINs ``pipeline_status`` as
+        ``ps`` — both aggregate callers replicate that join shape so the
+        pipeline/has_ocr predicates resolve. Keeping one builder means a brush
+        over the timeline filters by *exactly* the same predicates as the grid.
+        """
+        conditions: list[str] = []
+        params: dict = {}
+
+        if search:
+            terms = [t.strip() for t in search.split("||") if t.strip()]
+            if terms:
+                search_conds = []
+                for i, term in enumerate(terms):
+                    key = f"search{i}"
+                    search_conds.append(
+                        f"(a.p_number ILIKE %({key})s OR a.designation ILIKE %({key})s)"
+                    )
+                    params[key] = f"%{term}%"
+                conditions.append(f"({' OR '.join(search_conds)})")
+
+        if pipeline == "needs_reading":
+            conditions.append(
+                "(ps.reading_complete IS NULL OR ps.reading_complete < 0.5)"
+            )
+        elif pipeline == "needs_linguistic":
+            conditions.append(
+                "(ps.reading_complete > 0 AND (ps.linguistic_complete IS NULL OR ps.linguistic_complete < 0.5))"
+            )
+        elif pipeline == "complete":
+            conditions.append("(ps.semantic_complete >= 1.0)")
+
+        if period:
+            clause, p = self.build_in_clause(period, prefix="period")
+            conditions.append(f"a.period_normalized {clause}")
+            params.update(p)
+        if provenience:
+            clause, p = self.build_in_clause(provenience, prefix="prov")
+            conditions.append(f"a.provenience_normalized {clause}")
+            params.update(p)
+        if genre:
+            clause, p = self.build_in_clause(genre, prefix="genre")
+            conditions.append(f"""EXISTS (
+                SELECT 1 FROM artifact_genres ag
+                JOIN canonical_genres cg ON ag.genre_id = cg.id
+                WHERE ag.p_number = a.p_number AND cg.name {clause}
+            )""")
+            params.update(p)
+        if language:
+            clause, p = self.build_in_clause(language, prefix="lang")
+            conditions.append(f"""EXISTS (
+                SELECT 1 FROM artifact_languages al
+                JOIN canonical_languages cl ON al.language_id = cl.id
+                WHERE al.p_number = a.p_number AND cl.name {clause}
+            )""")
+            params.update(p)
+        if has_ocr:
+            conditions.append("ps.graphemic_complete > 0")
+
+        return conditions, params
+
+    def timeline_counts(
+        self,
+        search: str | None = None,
+        pipeline: str | None = None,
+        period: list[str] | None = None,
+        provenience: list[str] | None = None,
+        genre: list[str] | None = None,
+        language: list[str] | None = None,
+        has_ocr: bool = False,
+    ) -> list[dict]:
+        """Per-period tablet counts, cross-filtered by every *other* dimension
+        but NOT by the period brush itself, joined to period_canon for BCE date
+        ranges + chronological ordering.
+
+        Powers the Corpus-Atlas timeline (Wave 1, #320). Excluding period from
+        its own WHERE (the same self-exclusion the sidebar checkbox counts use)
+        is what makes the chart a usable filter control: brushing Ur III must
+        leave Old Babylonian visible so a scholar can add it (OR-within-period
+        = union), per the spec. The grid still filters by period; only this
+        chart shows all periods, with the brushed ones highlighted client-side.
+
+        Deliberately does NOT read pipeline_completeness (the #257 landmine) —
+        it only reads pipeline_status, the same table search() uses.
+        """
+        # Exclude the period filter from the timeline's own counts (cross-filter
+        # self-exclusion) so every period stays selectable from the chart.
+        conditions, params = self._build_search_where(
+            search=search,
+            pipeline=pipeline,
+            period=None,
+            provenience=provenience,
+            genre=genre,
+            language=language,
+            has_ocr=has_ocr,
+        )
+        where = "WHERE " + " AND ".join(conditions) if conditions else ""
+        rows = self.fetch_all(
+            f"""
+            SELECT a.period_normalized AS canonical,
+                   pc.date_start_bce,
+                   pc.date_end_bce,
+                   pc.group_name,
+                   pc.sort_order,
+                   COUNT(*) AS count
+            FROM artifacts a
+            LEFT JOIN pipeline_status ps ON a.p_number = ps.p_number
+            LEFT JOIN (
+                SELECT DISTINCT ON (canonical)
+                    canonical, date_start_bce, date_end_bce,
+                    group_name, sort_order
+                FROM period_canon
+                ORDER BY canonical, sort_order NULLS LAST
+            ) pc ON pc.canonical = a.period_normalized
+            {where}
+            {"AND" if where else "WHERE"} a.period_normalized IS NOT NULL
+            GROUP BY a.period_normalized, pc.date_start_bce, pc.date_end_bce,
+                     pc.group_name, pc.sort_order
+            ORDER BY pc.sort_order NULLS LAST, count DESC
+        """,
+            params,
+        )
+        return rows
+
+    def site_counts(
+        self,
+        search: str | None = None,
+        pipeline: str | None = None,
+        period: list[str] | None = None,
+        provenience: list[str] | None = None,
+        genre: list[str] | None = None,
+        language: list[str] | None = None,
+        has_ocr: bool = False,
+        limit: int = 25,
+    ) -> list[dict]:
+        """Ranked find-spots (provenience) by tablet count, cross-filtered by
+        every *other* dimension but NOT by the provenience brush itself — the
+        coordinate-free geography lens for Wave 1 (#320).
+
+        Self-excluding provenience (same as the timeline excludes period) keeps
+        every find-spot visible/selectable from the list after one is brushed,
+        so a scholar can union two sites. Excludes the literal 'uncertain'
+        provenience (25k rows with no place meaning) and null provenience. Joins
+        provenience_canon for the region label. Top ``limit`` only.
+        """
+        conditions, params = self._build_search_where(
+            search=search,
+            pipeline=pipeline,
+            period=period,
+            provenience=None,
+            genre=genre,
+            language=language,
+            has_ocr=has_ocr,
+        )
+        conditions.append("a.provenience_normalized IS NOT NULL")
+        conditions.append("a.provenience_normalized <> 'uncertain'")
+        where = "WHERE " + " AND ".join(conditions)
+        params["site_limit"] = limit
+        rows = self.fetch_all(
+            f"""
+            SELECT a.provenience_normalized AS ancient_name,
+                   COALESCE(pc.region, 'Unknown') AS region,
+                   COUNT(*) AS count
+            FROM artifacts a
+            LEFT JOIN pipeline_status ps ON a.p_number = ps.p_number
+            LEFT JOIN (
+                SELECT DISTINCT ON (ancient_name) ancient_name, region
+                FROM provenience_canon
+                ORDER BY ancient_name, sort_order NULLS LAST
+            ) pc ON pc.ancient_name = a.provenience_normalized
+            {where}
+            GROUP BY a.provenience_normalized, pc.region
+            ORDER BY count DESC
+            LIMIT %(site_limit)s
+        """,
+            params,
+        )
+        return rows
+
     def search(
         self,
         search: str | None = None,

--- a/api/routes/artifacts.py
+++ b/api/routes/artifacts.py
@@ -78,6 +78,67 @@ def search_artifacts(
     return result
 
 
+@router.get("/timeline")
+def artifacts_timeline(
+    search: str | None = None,
+    pipeline: str | None = None,
+    period: list[str] = Query(default=[]),
+    provenience: list[str] = Query(default=[]),
+    genre: list[str] = Query(default=[]),
+    language: list[str] = Query(default=[]),
+    has_ocr: bool = False,
+    conn=Depends(get_db),
+):
+    """Per-period tablet counts over the current filter, for the Corpus-Atlas
+    timeline view (#320). Returns {"items": [{canonical, date_start_bce,
+    date_end_bce, group_name, count}, ...]} ordered chronologically.
+
+    Accepts the same filter params as GET /artifacts so a brushed slice on the
+    timeline reflects exactly the grid's active filters.
+    """
+    repo = ArtifactRepository(conn)
+    items = repo.timeline_counts(
+        search=search,
+        pipeline=pipeline,
+        period=period or None,
+        provenience=provenience or None,
+        genre=genre or None,
+        language=language or None,
+        has_ocr=has_ocr,
+    )
+    return {"items": items}
+
+
+@router.get("/by-site")
+def artifacts_by_site(
+    search: str | None = None,
+    pipeline: str | None = None,
+    period: list[str] = Query(default=[]),
+    provenience: list[str] = Query(default=[]),
+    genre: list[str] = Query(default=[]),
+    language: list[str] = Query(default=[]),
+    has_ocr: bool = False,
+    limit: int = 25,
+    conn=Depends(get_db),
+):
+    """Ranked find-spots by tablet count over the current filter — the
+    coordinate-free geography lens for the Corpus-Atlas (#320). Returns
+    {"items": [{ancient_name, region, count}, ...]}, 'uncertain' excluded.
+    """
+    repo = ArtifactRepository(conn)
+    items = repo.site_counts(
+        search=search,
+        pipeline=pipeline,
+        period=period or None,
+        provenience=provenience or None,
+        genre=genre or None,
+        language=language or None,
+        has_ocr=has_ocr,
+        limit=min(max(limit, 1), 100),
+    )
+    return {"items": items}
+
+
 @router.get("/{p_number}")
 def get_artifact(p_number: str, conn=Depends(get_db)):
     repo = ArtifactRepository(conn)

--- a/app/api_client.py
+++ b/app/api_client.py
@@ -124,6 +124,27 @@ class GlintstoneAPI:
         except Exception:
             return {}
 
+    def get_artifacts_timeline(self, params: dict) -> list:
+        """Per-period counts over the current filter (Corpus-Atlas timeline).
+
+        Degrades to an empty list on any failure so the timeline view falls
+        back to its plain period-count rendering rather than 500-ing the page.
+        """
+        try:
+            result = self._t.get("/artifacts/timeline", params=params)
+            return result.get("items", []) if isinstance(result, dict) else []
+        except Exception:
+            return []
+
+    def get_artifacts_by_site(self, params: dict) -> list:
+        """Ranked find-spots by tablet count over the current filter
+        (Corpus-Atlas geography lens). Empty list on failure."""
+        try:
+            result = self._t.get("/artifacts/by-site", params=params)
+            return result.get("items", []) if isinstance(result, dict) else []
+        except Exception:
+            return []
+
     def get_artifact_debug(self, p_number: str) -> dict:
         try:
             return self._t.get(f"/artifacts/{p_number}/debug")  # type: ignore[return-value]

--- a/app/routes/tablets.py
+++ b/app/routes/tablets.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 from pathlib import Path
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import RedirectResponse
@@ -16,6 +17,82 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/tablets")
 
 
+def _atlas_filter_params(
+    search: str,
+    pipeline: str,
+    period: list[str],
+    provenience: list[str],
+    genre: list[str],
+    language: list[str],
+    has_ocr: str,
+) -> dict:
+    """Build the filter params (sans pagination) shared by the timeline and
+    by-site aggregate calls — exactly the predicates the grid uses, so a brush
+    re-filters the corpus the same way the checkboxes do."""
+    p: dict = {}
+    if search:
+        p["search"] = search
+    if pipeline:
+        p["pipeline"] = pipeline
+    if period:
+        p["period"] = period
+    if provenience:
+        p["provenience"] = provenience
+    if genre:
+        p["genre"] = genre
+    if language:
+        p["language"] = language
+    if has_ocr:
+        p["has_ocr"] = "true"
+    return p
+
+
+def _timeline_axis(rows: list[dict]) -> list[dict]:
+    """Decorate per-period rows with log-scaled bar geometry + proportional BCE
+    position so the Timeline view renders honestly without JS (Tufte: log scale
+    keeps the 111k Ur III skew from drowning the small periods).
+
+    Adds to each row:
+      - ``bar_width``: percent width of the count bar (log10-scaled).
+      - ``bar_left``: percent offset on the shared 3000→0 BCE axis (from
+        date_start_bce); 0 when the period has no canonical date.
+    The axis spans 3000 BCE (left) to 0 (right). Counts are scaled so the
+    largest period reads ~100%% and a single tablet still shows a visible stub.
+    """
+    AXIS_MAX_BCE = 3000.0
+    if not rows:
+        return []
+    max_count = max((r.get("count") or 0) for r in rows) or 1
+    log_max = math.log10(max_count + 1) or 1.0
+    out: list[dict] = []
+    for r in rows:
+        count = r.get("count") or 0
+        # log-scale the bar; floor at 4% so tiny periods stay clickable/visible
+        width = max(4.0, (math.log10(count + 1) / log_max) * 100.0)
+        # Anchor the count-bar at the date the period *starts* on the shared
+        # BCE axis, then clamp its width so it never runs past the right edge of
+        # the track (left + width <= 100). This keeps the bar both positioned in
+        # time (where on the 3000→0 BCE axis) and sized by count (log), matching
+        # the Tufte coverage-matrix encoding in the spec without overflow.
+        start = r.get("date_start_bce")
+        if start is not None:
+            bce = abs(start)
+            # Axis runs 3000 BCE (0%) → 0 BCE (100%). Periods older than 3000
+            # BCE pin to the left edge.
+            left = max(0.0, min(96.0, (1 - bce / AXIS_MAX_BCE) * 100.0))
+        else:
+            left = 0.0
+        width = min(width, 100.0 - left)
+        out.append(
+            {
+                **r,
+                "bar_width": round(width, 1),
+                "bar_left": round(left, 1),
+            }
+        )
+    return out
+
+
 @router.get("")
 def tablet_list(
     request: Request,
@@ -27,8 +104,14 @@ def tablet_list(
     language: list[str] = Query(default=[]),
     has_ocr: str = "",
     page: int = 1,
+    view: str = "grid",
 ):
     api = request.app.state.api
+    # Only grid / timeline are real views in Wave 1 (#320). The map is Wave 2
+    # (gated on migration 049 + geocoding, #319) — anything unknown falls back
+    # to the grid so a stale/shared URL never lands on a blank view.
+    if view not in ("grid", "timeline"):
+        view = "grid"
     # include_filter_options=true lets the API return both the page and the
     # cross-filter counts in a single round trip — half the latency of two
     # sequential httpx calls.
@@ -49,6 +132,16 @@ def tablet_list(
         params["has_ocr"] = "true"
 
     artifact_page = api.list_artifacts(params)
+
+    # Corpus-Atlas aggregates (#320): per-period counts (timeline) + ranked
+    # find-spots (geography lens), both over the SAME active filter as the grid.
+    # Fetched on every load so the view-switcher flips instantly client-side and
+    # the no-JS fallback server-renders whichever view the URL asked for.
+    atlas_params = _atlas_filter_params(
+        search, pipeline, period, provenience, genre, language, has_ocr
+    )
+    timeline_rows = _timeline_axis(api.get_artifacts_timeline(atlas_params))
+    site_rows = api.get_artifacts_by_site({**atlas_params, "limit": 12})
 
     lv = build_filtered_list(
         scope="tablets",
@@ -86,6 +179,9 @@ def tablet_list(
             "filter_options": lv.filter_options,
             "active_filters": active_filters_as_dicts(lv),
             "api_url": request.app.state.api.base_url,
+            "view": view,
+            "timeline_rows": timeline_rows,
+            "site_rows": site_rows,
         },
     )
 

--- a/app/static/css/components/corpus-atlas.css
+++ b/app/static/css/components/corpus-atlas.css
@@ -1,0 +1,218 @@
+/* ─── Corpus Atlas (Wave 1, #320) ────────────────────────────────────────────
+   View-switcher (Grid / Timeline) + brushable timeline + find-spots-by-yield
+   over the all-artifacts page. Ported from the render-proven prototype at
+   PERSONAL/design/specs/all-artifacts/. Token-driven only — no raw hex.
+   Map view is Wave 2 (gated on #319), intentionally absent here. */
+
+/* View switcher — segmented control (reuses btn-group visual language) */
+.corpus-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+  flex-wrap: wrap;
+}
+.view-switch {
+  display: inline-flex;
+  background: var(--surface-raised);
+  border: var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 3px;
+  gap: 2px;
+}
+.view-switch a {
+  cursor: pointer;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  transition: var(--transition-fast);
+}
+.view-switch a:hover { color: var(--color-text); }
+.view-switch a[aria-pressed="true"] {
+  background: var(--color-accent-20);
+  color: var(--color-accent-hover);
+}
+.view-switch svg { width: 15px; height: 15px; }
+
+/* Linked-filter banner — explains the active brush */
+.linked-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  background: var(--color-accent-10);
+  border: 1px solid var(--color-accent-30);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-4);
+  color: var(--color-text);
+}
+.linked-banner svg { flex-shrink: 0; color: var(--color-accent-hover); }
+.linked-banner strong { color: var(--color-accent-hover); }
+.linked-banner .clear {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
+/* ── Timeline view: small-multiple coverage rows on a shared BCE axis ─────── */
+.tl-panel {
+  background: var(--surface-raised);
+  border: var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-6) var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.tl-panel__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+.tl-panel__head h2 {
+  font-size: var(--text-lg);
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+}
+.tl-panel__head .hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
+}
+
+.tl-row {
+  display: grid;
+  grid-template-columns: 140px 1fr 64px;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: var(--transition-fast);
+  text-decoration: none;
+  color: inherit;
+}
+.tl-row:hover { background: var(--color-overlay-light); }
+.tl-row__label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tl-row__label .yr {
+  display: block;
+  color: var(--color-text-subtle);
+  font-size: var(--text-xxs);
+}
+.tl-row__track { position: relative; height: 18px; }
+.tl-row__bar {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 10px;
+  background: var(--color-accent);
+  border-radius: var(--radius-xs);
+  opacity: 0.85;
+  transition: var(--transition-fast);
+}
+.tl-row__bar.is-dim { opacity: 0.18; }
+.tl-row__count {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.tl-row.is-selected { background: var(--color-accent-15); }
+.tl-row.is-selected .tl-row__bar { opacity: 1; }
+
+.tl-axis {
+  display: grid;
+  grid-template-columns: 140px 1fr 64px;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  border-top: var(--border-subtle);
+  padding-top: var(--space-2);
+}
+.tl-axis__ticks {
+  grid-column: 2;
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-xxs);
+  color: var(--color-text-subtle);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Find-spots by yield: coordinate-free ranked bar-list (Wave-1 geography) ─ */
+.atlas-sites {
+  background: var(--surface-raised);
+  border: var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-6);
+  margin-bottom: var(--space-5);
+}
+.atlas-sites h2 {
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-subtle);
+  margin: 0 0 var(--space-4);
+}
+.site-rank { list-style: none; margin: 0; padding: 0; }
+.site-rank li { margin-bottom: var(--space-1); }
+.site-rank a {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  text-decoration: none;
+  color: inherit;
+}
+.site-rank a:hover,
+.site-rank li.is-active a { background: var(--color-overlay-light); }
+.site-rank .name { font-size: var(--text-sm); }
+.site-rank .name small {
+  display: block;
+  color: var(--color-text-subtle);
+  font-size: var(--text-xxs);
+}
+.site-rank .ct {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.site-rank .barline {
+  grid-column: 1 / 3;
+  height: 3px;
+  background: var(--color-accent);
+  border-radius: 2px;
+  opacity: 0.5;
+  margin-top: 2px;
+}
+.atlas-sites .map-cov {
+  font-size: var(--text-xxs);
+  color: var(--color-warning);
+  margin: var(--space-3) 0 0;
+  border-top: var(--border-subtle);
+  padding-top: var(--space-2);
+}
+
+@media (max-width: 640px) {
+  .tl-row,
+  .tl-axis { grid-template-columns: 110px 1fr 52px; }
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -23,6 +23,7 @@
 @import url('components/stage-filter.css');
 @import url('components/pagination.css');
 @import url('components/empty-states.css');
+@import url('components/corpus-atlas.css');
 @import url('components/forms.css');
 @import url('components/global-search.css');
 @import url('components/filters.css');

--- a/app/static/js/corpus-atlas.js
+++ b/app/static/js/corpus-atlas.js
@@ -1,0 +1,92 @@
+/* Corpus Atlas (Wave 1, #320) — progressive enhancement over the
+ * server-rendered all-artifacts page.
+ *
+ * Every brush target (view-switch link, timeline period row, find-spot row) is
+ * already a real <a href> that server-renders the correct slice — this script
+ * just makes the interaction *live*: intercept the click, fetch the target URL,
+ * and swap the changed regions in place + pushState (shareable, back-safe).
+ * With JS off, the links navigate normally and nothing here is needed.
+ *
+ * Bret Victor's note from the spec: the chart IS the filter control. Clicking a
+ * period or a find-spot re-filters the grid below without a full reload. */
+(function () {
+  'use strict';
+
+  var REGIONS = [
+    '[data-atlas-grid]',     // the result grid
+    '[data-atlas-timeline]', // the timeline panel (selection state)
+    '[data-atlas-sites]',    // the find-spots list
+    '[data-atlas-banner]',   // the linked-filter banner
+    '[data-atlas-switch]',   // the view switcher (aria-pressed)
+    '.active-filters',        // active filter pills
+    '.pagination'             // pagination base links
+  ];
+
+  var main = document.querySelector('.main-content');
+  if (!main) return;
+
+  function isAtlasLink(a) {
+    if (!a) return false;
+    return a.matches(
+      '[data-atlas-switch] a, [data-atlas-timeline] a, [data-atlas-sites] a, [data-atlas-banner] .clear'
+    );
+  }
+
+  function swapFrom(doc) {
+    REGIONS.forEach(function (sel) {
+      var incoming = doc.querySelectorAll(sel);
+      var current = document.querySelectorAll(sel);
+      // Region may appear/disappear (e.g. timeline panel only in timeline view,
+      // banner only when a brush is active). Replace 1:1 where both exist;
+      // otherwise rebuild the whole main-content as a safe fallback.
+      if (incoming.length === current.length && current.length > 0) {
+        current.forEach(function (el, i) {
+          el.replaceWith(incoming[i]);
+        });
+      }
+    });
+  }
+
+  function navigate(url, push) {
+    main.setAttribute('aria-busy', 'true');
+    fetch(url, { headers: { 'X-Requested-With': 'fetch' } })
+      .then(function (r) { return r.text(); })
+      .then(function (html) {
+        var doc = new DOMParser().parseFromString(html, 'text/html');
+        var newMain = doc.querySelector('.main-content');
+        if (!newMain) { window.location.assign(url); return; }
+        // Try region-level swap; if region counts diverged, replace wholesale.
+        var same = REGIONS.every(function (sel) {
+          return doc.querySelectorAll(sel).length === document.querySelectorAll(sel).length;
+        });
+        if (same) {
+          swapFrom(doc);
+        } else {
+          main.replaceWith(newMain);
+          main = document.querySelector('.main-content');
+        }
+        if (push) { history.pushState({ atlas: true }, '', url); }
+        var title = doc.querySelector('title');
+        if (title) { document.title = title.textContent; }
+      })
+      .catch(function () { window.location.assign(url); })
+      .finally(function () {
+        var m = document.querySelector('.main-content');
+        if (m) { m.removeAttribute('aria-busy'); }
+      });
+  }
+
+  // Delegate: one listener survives DOM swaps.
+  document.addEventListener('click', function (e) {
+    var a = e.target.closest('a');
+    if (!a || !isAtlasLink(a)) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+    e.preventDefault();
+    navigate(a.getAttribute('href'), true);
+  });
+
+  // Back/forward button: re-fetch the popped URL without pushing again.
+  window.addEventListener('popstate', function () {
+    navigate(window.location.href, false);
+  });
+})();

--- a/app/templates/tablets/list.html
+++ b/app/templates/tablets/list.html
@@ -19,18 +19,10 @@
     ) }}
 
     <div class="main-content">
-        <div class="page-header">
-            <div class="page-header-main">
-                <div class="page-header-title">
-                    <h1>Tablets</h1>
-                    <p class="subtitle">
-                        Showing {{ '{:,}'.format(total) }} tablets
-                    </p>
-                </div>
-            </div>
-        </div>
 
-        {# Build filter query string for stage filter + pagination links #}
+        {# ── Shared filter query string (sans view/page) reused by switcher,
+             brush links, stage filter and pagination. Keeps every brush target
+             a real <a href> that server-renders the same slice (no-JS rule). #}
         {% set fq = namespace(s='') %}
         {% if search %}{% set fq.s = fq.s ~ 'search=' ~ (search|urlencode) ~ '&' %}{% endif %}
         {% for p in period %}{% set fq.s = fq.s ~ 'period=' ~ (p|urlencode) ~ '&' %}{% endfor %}
@@ -38,14 +30,121 @@
         {% for g in genre %}{% set fq.s = fq.s ~ 'genre=' ~ (g|urlencode) ~ '&' %}{% endfor %}
         {% for l in language %}{% set fq.s = fq.s ~ 'language=' ~ (l|urlencode) ~ '&' %}{% endfor %}
         {% if has_ocr %}{% set fq.s = fq.s ~ 'has_ocr=1&' %}{% endif %}
+        {% if pipeline %}{% set fq.s = fq.s ~ 'pipeline=' ~ (pipeline|urlencode) ~ '&' %}{% endif %}
 
+        {# ── Corpus toolbar: title + view switcher (Grid / Timeline) ───────── #}
+        <div class="corpus-toolbar">
+            <div class="page-header-title">
+                <h1>Tablets</h1>
+                <p class="subtitle">Showing {{ '{:,}'.format(total) }} tablets</p>
+            </div>
+            <nav class="view-switch" role="group" aria-label="Corpus view" data-atlas-switch>
+                <a href="/tablets?{{ fq.s }}view=grid"
+                   data-view="grid"
+                   aria-pressed="{{ 'true' if view == 'grid' else 'false' }}">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>Grid</a>
+                <a href="/tablets?{{ fq.s }}view=timeline"
+                   data-view="timeline"
+                   aria-pressed="{{ 'true' if view == 'timeline' else 'false' }}">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="15" y2="12"/><line x1="3" y1="18" x2="19" y2="18"/></svg>Timeline</a>
+            </nav>
+        </div>
+
+        {# ── Linked-filter banner: shows the active brush + a clear affordance #}
+        {% if period or provenience %}
+        <div class="linked-banner" data-atlas-banner>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
+            Brushing
+            {% for p in period %}<strong>{{ p }}</strong>{% if not loop.last or provenience %} · {% endif %}{% endfor %}
+            {% for s in provenience %}<strong>{{ s }}</strong>{% if not loop.last %} · {% endif %}{% endfor %}
+            — <strong>{{ '{:,}'.format(total) }}</strong> matching tablets.
+            <a class="clear" href="/tablets?view={{ view }}{% if pipeline %}&pipeline={{ pipeline|urlencode }}{% endif %}">Clear selection ×</a>
+        </div>
+        {% endif %}
+
+        {# ── TIMELINE view: small-multiple coverage rows, brushable ────────── #}
+        {% if view == 'timeline' %}
+        <div class="tl-panel" data-atlas-timeline>
+            <div class="tl-panel__head">
+                <h2>Corpus across time</h2>
+                <span class="hint">Click a period to filter · bar length = tablet count (log)</span>
+            </div>
+            {% for row in timeline_rows %}
+                {% set is_sel = row.canonical in period %}
+                {% set tq = namespace(s='') %}
+                {% if search %}{% set tq.s = tq.s ~ 'search=' ~ (search|urlencode) ~ '&' %}{% endif %}
+                {% for p in period if p != row.canonical %}{% set tq.s = tq.s ~ 'period=' ~ (p|urlencode) ~ '&' %}{% endfor %}
+                {% if not is_sel %}{% set tq.s = tq.s ~ 'period=' ~ (row.canonical|urlencode) ~ '&' %}{% endif %}
+                {% for p in provenience %}{% set tq.s = tq.s ~ 'provenience=' ~ (p|urlencode) ~ '&' %}{% endfor %}
+                {% for g in genre %}{% set tq.s = tq.s ~ 'genre=' ~ (g|urlencode) ~ '&' %}{% endfor %}
+                {% for l in language %}{% set tq.s = tq.s ~ 'language=' ~ (l|urlencode) ~ '&' %}{% endfor %}
+                {% if has_ocr %}{% set tq.s = tq.s ~ 'has_ocr=1&' %}{% endif %}
+                {% if pipeline %}{% set tq.s = tq.s ~ 'pipeline=' ~ (pipeline|urlencode) ~ '&' %}{% endif %}
+                <a class="tl-row{{ ' is-selected' if is_sel }}"
+                   href="/tablets?{{ tq.s }}view=timeline"
+                   data-period="{{ row.canonical }}"
+                   aria-pressed="{{ 'true' if is_sel else 'false' }}">
+                    <div class="tl-row__label">{{ row.canonical }}
+                        {% if row.date_start_bce %}<span class="yr">{{ row.date_start_bce|abs }}{% if row.date_end_bce %}–{{ row.date_end_bce|abs }}{% endif %} BCE</span>{% endif %}
+                    </div>
+                    <div class="tl-row__track">
+                        <div class="tl-row__bar{{ '' if (is_sel or not (period or provenience)) else ' is-dim' }}"
+                             style="left:{{ row.bar_left }}%; width:{{ row.bar_width }}%;"></div>
+                    </div>
+                    <div class="tl-row__count">{{ '{:,}'.format(row.count) }}</div>
+                </a>
+            {% else %}
+                <p class="subtitle">No period data for this slice.</p>
+            {% endfor %}
+            <div class="tl-axis">
+                <div class="tl-axis__ticks">
+                    <span>3000</span><span>2500</span><span>2000</span><span>1500</span><span>1000</span><span>500</span><span>BCE</span>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
+        {# ── Find-spots by yield: coordinate-free ranked bar-list (Wave 1) ─── #}
+        {% if site_rows %}
+        <div class="atlas-sites" data-atlas-sites>
+            <h2>Find-spots by yield</h2>
+            {% set top_ct = site_rows[0].count or 1 %}
+            <ul class="site-rank">
+                {% for s in site_rows %}
+                {% set is_sel = s.ancient_name in provenience %}
+                {% set sq = namespace(s='') %}
+                {% if search %}{% set sq.s = sq.s ~ 'search=' ~ (search|urlencode) ~ '&' %}{% endif %}
+                {% for p in period %}{% set sq.s = sq.s ~ 'period=' ~ (p|urlencode) ~ '&' %}{% endfor %}
+                {% for p in provenience if p != s.ancient_name %}{% set sq.s = sq.s ~ 'provenience=' ~ (p|urlencode) ~ '&' %}{% endfor %}
+                {% if not is_sel %}{% set sq.s = sq.s ~ 'provenience=' ~ (s.ancient_name|urlencode) ~ '&' %}{% endif %}
+                {% for g in genre %}{% set sq.s = sq.s ~ 'genre=' ~ (g|urlencode) ~ '&' %}{% endfor %}
+                {% for l in language %}{% set sq.s = sq.s ~ 'language=' ~ (l|urlencode) ~ '&' %}{% endfor %}
+                {% if has_ocr %}{% set sq.s = sq.s ~ 'has_ocr=1&' %}{% endif %}
+                {% if pipeline %}{% set sq.s = sq.s ~ 'pipeline=' ~ (pipeline|urlencode) ~ '&' %}{% endif %}
+                <li class="{{ 'is-active' if is_sel }}">
+                    <a href="/tablets?{{ sq.s }}view={{ view }}"
+                       data-site="{{ s.ancient_name }}"
+                       aria-pressed="{{ 'true' if is_sel else 'false' }}">
+                        <span class="name">{{ s.ancient_name }} <small>{{ s.region }}</small></span>
+                        <span class="ct">{{ '{:,}'.format(s.count) }}</span>
+                        <span class="barline" style="width:{{ (100 * s.count / top_ct)|round(0, 'floor')|int }}%;"></span>
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            <p class="map-cov">⚠ Coverage: tablets with "uncertain" provenience are omitted. Geographic map view arrives once site coordinates are geocoded (Wave 2).</p>
+        </div>
+        {% endif %}
+
+        {# ── Stage filter (pipeline) ──────────────────────────────────────── #}
+        {% set sfq = fq.s ~ ('view=' ~ view ~ '&') %}
         {% set stages = [
             {'label': 'All', 'value': ''},
             {'label': 'Needs transliteration', 'value': 'needs_reading'},
             {'label': 'Needs lemmatization', 'value': 'needs_linguistic'},
             {'label': 'Complete', 'value': 'complete'},
         ] %}
-        {{ stage_filter(stages, pipeline or '', '/tablets', extra_params=fq.s, has_ocr=has_ocr or '') }}
+        {{ stage_filter(stages, pipeline or '', '/tablets', extra_params=sfq, has_ocr=has_ocr or '') }}
 
         {# Active filter pills #}
         {% if active_filters %}
@@ -58,26 +157,27 @@
                 </a>
                 {% endfor %}
             </div>
-            <a href="/tablets{% if pipeline %}?pipeline={{ pipeline }}{% endif %}" class="active-filters__clear">Clear all</a>
+            <a href="/tablets?view={{ view }}{% if pipeline %}&pipeline={{ pipeline }}{% endif %}" class="active-filters__clear">Clear all</a>
         </div>
         {% endif %}
 
-        <div class="tablet-grid">
+        {# ── Shared result grid: the SAME list, filtered by the brush ──────── #}
+        <div class="tablet-grid" data-atlas-grid>
             {% for tablet in tablets %}
                 {{ tablet_card(tablet, api_url=api_url) }}
             {% else %}
             <div class="empty-state">
                 <div class="empty-icon">&#x12000;</div>
-                <h3>No tablets found</h3>
-                <p>Try adjusting your search or filters.</p>
+                <h3>No tablets in this slice</h3>
+                <p>Try clearing the brush or adjusting your filters.</p>
             </div>
             {% endfor %}
         </div>
 
-        {% set base = '/tablets?' ~ fq.s %}
-        {% if pipeline %}{% set base = base ~ 'pipeline=' ~ pipeline ~ '&' %}{% endif %}
+        {% set base = '/tablets?' ~ fq.s ~ 'view=' ~ view ~ '&' %}
         {{ pagination(page, total_pages, base) }}
     </div>
 </div>
 </main>
+<script src="/static/js/corpus-atlas.js" defer></script>
 {% endblock %}

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -78,6 +78,54 @@ def test_get_artifact_returns_empty_on_failure():
     assert api.get_artifact("P000001") == {}
 
 
+# ── Corpus Atlas aggregates (#320) ───────────────────────────────────────────
+
+
+def test_timeline_empty_on_missing_fixture():
+    api = make_api({})
+    assert api.get_artifacts_timeline({}) == []
+
+
+def test_timeline_returns_items():
+    api = make_api(
+        {
+            "/artifacts/timeline": {
+                "items": [
+                    {"canonical": "Ur III", "count": 111285, "date_start_bce": 2112}
+                ]
+            }
+        }
+    )
+    rows = api.get_artifacts_timeline({})
+    assert len(rows) == 1
+    assert rows[0]["canonical"] == "Ur III"
+    assert rows[0]["count"] == 111285
+
+
+def test_by_site_empty_on_missing_fixture():
+    api = make_api({})
+    assert api.get_artifacts_by_site({}) == []
+
+
+def test_by_site_returns_items():
+    api = make_api(
+        {
+            "/artifacts/by-site": {
+                "items": [
+                    {
+                        "ancient_name": "Girsu",
+                        "region": "South Mesopotamia",
+                        "count": 38153,
+                    }
+                ]
+            }
+        }
+    )
+    rows = api.get_artifacts_by_site({})
+    assert rows[0]["ancient_name"] == "Girsu"
+    assert rows[0]["count"] == 38153
+
+
 def test_get_artifact_returns_fixture():
     api = make_api({"/artifacts/P000001": {"p_number": "P000001", "title": "Test"}})
     result = api.get_artifact("P000001")

--- a/tests/web/test_corpus_atlas.py
+++ b/tests/web/test_corpus_atlas.py
@@ -1,0 +1,59 @@
+"""Corpus Atlas (#320) — timeline axis geometry.
+
+_timeline_axis turns raw per-period counts into log-scaled bar widths and
+proportional BCE positions so the server-rendered timeline reads honestly
+(Tufte: the 111k Ur III skew must not drown small periods). These tests pin the
+load-bearing math, independent of the database.
+"""
+
+from app.routes.tablets import _timeline_axis
+
+
+def test_timeline_axis_empty():
+    assert _timeline_axis([]) == []
+
+
+def test_log_scale_keeps_small_periods_visible():
+    rows = _timeline_axis(
+        [
+            {"canonical": "Ur III", "count": 111285, "date_start_bce": 2112},
+            {"canonical": "Tiny", "count": 3, "date_start_bce": 1000},
+        ]
+    )
+    big, tiny = rows[0], rows[1]
+    # The largest period dominates the log scale, so its (unclamped) width is
+    # far larger than the tiny period's — and both stay on-track (the bar never
+    # runs past the right edge: left + width <= 100).
+    assert big["bar_width"] > tiny["bar_width"]
+    assert big["bar_left"] + big["bar_width"] <= 100.0
+    # A 3-tablet period still gets a visible stub (well above its ~0.003%
+    # raw-linear share).
+    assert tiny["bar_width"] >= 4.0
+
+
+def test_bar_never_overflows_track():
+    rows = _timeline_axis(
+        [
+            # late, count-heavy period: large width + far-right start would
+            # overflow without the clamp.
+            {"canonical": "Neo-Babylonian", "count": 90000, "date_start_bce": 626},
+            {"canonical": "Pre-Uruk", "count": 200, "date_start_bce": 8500},
+        ]
+    )
+    for r in rows:
+        assert r["bar_left"] + r["bar_width"] <= 100.0
+        assert r["bar_left"] >= 0.0
+
+
+def test_bce_position_maps_onto_3000_to_0_axis():
+    [row] = _timeline_axis([{"canonical": "P", "count": 10, "date_start_bce": 1500}])
+    # 1500 BCE is the midpoint of the 3000→0 axis → ~50% from the left.
+    assert 49.0 <= row["bar_left"] <= 51.0
+
+
+def test_undated_period_pins_left_and_still_bars():
+    [row] = _timeline_axis(
+        [{"canonical": "Undated", "count": 500, "date_start_bce": None}]
+    )
+    assert row["bar_left"] == 0.0
+    assert row["bar_width"] >= 4.0

--- a/tests/web/test_global_search.py
+++ b/tests/web/test_global_search.py
@@ -76,6 +76,12 @@ class _FakeAPI:
     def get_artifact(self, p_number, token=None):
         return self.envelope if isinstance(self.envelope, dict) else {}
 
+    def get_artifacts_timeline(self, params):
+        return []
+
+    def get_artifacts_by_site(self, params):
+        return []
+
     def get_artifact_debug(self, p_number):
         return {}
 


### PR DESCRIPTION
Builds **Corpus Atlas Wave 1** on the all-artifacts (/tablets) page, to the render-proven spec at \`PERSONAL/design/specs/all-artifacts/\`. No geographic map — that is Wave 2 (now unblocked by #319).

## What this adds
- **View-switcher** (Grid / Timeline) via \`?view=\`, Grid default.
- **Timeline** — a Tufte coverage matrix: every period as a small-multiple row, bar positioned on a shared 3000→0 BCE axis and log-sized by count (honest about the Ur III skew). Brushing a period writes the existing \`?period=\` param → the grid re-filters live. The chart cross-filters by every *other* dimension but self-excludes period, so all periods stay selectable (OR union: Ur III + Old Babylonian = 178,118).
- **Find-spots by yield** — a coordinate-free ranked bar-list over provenience (\`uncertain\` excluded). Clicking a site sets \`?provenience=\`.
- **Two aggregate endpoints** — \`GET /artifacts/timeline\` + \`/artifacts/by-site\`, same filter params as the grid. Read only \`pipeline_status\` (not \`pipeline_completeness\`, the #257 landmine).
- **No-JS fallback**: every brush target is a real \`<a href>\` that server-renders the slice; \`corpus-atlas.js\` enhances to fetch-and-swap + pushState (shareable, back-safe).
- \`corpus-atlas.css\`: token-driven, no raw hex.

## Verification
- Gate green: ruff + format + mypy + pytest (362 passed).
- Render-verified against the prototype with the live 353,283-artifact corpus: the timeline coverage matrix, brush→grid re-filter, find-spots list, and shareable URL params all reproduce the spec (the 178,118 brush example matches exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)