### PR TITLE
chore(batch-2): PRD-017 route tests, ingestion typing, deploy verify helper, JS era harness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,17 @@ jobs:
 
       - name: Type-check (mypy)
         # Blocking: the codebase is now clean under mypy across these packages
-        # (audit finding 3a). New type errors fail CI.
+        # (audit finding 3a). New type errors fail CI. ingestion/ was brought
+        # under coverage in #137 (the recurring "pre-existing mypy errors in
+        # ingestion/" noise is now fixed at the source).
         run: |
-          mypy api/ app/ core/ mcp/ --ignore-missing-imports
+          mypy api/ app/ core/ mcp/ ingestion/ --ignore-missing-imports
+
+      - name: JS unit tests (timeline era-suffix formatters, #386)
+        # No npm install — Node's built-in test runner + node:assert. Guards the
+        # dual-era BCE/CE formatters (#332) against silent regression.
+        run: |
+          node --test 'tests/js/*.test.mjs'
 
       - name: Run pytest
         # Integration tests (those depending on `has_database_url`) are skipped

--- a/app/static/js/header-auth.js
+++ b/app/static/js/header-auth.js
@@ -1,0 +1,39 @@
+/**
+ * header-auth.js — populate the header user chip from the current session.
+ *
+ * Extracted verbatim from the inline IIFE in base.html (frontend audit finding
+ * F-5, #125): the script was tightly coupled to the header markup yet lived
+ * inline, so it could not be cached, linted, or reasoned about on its own.
+ *
+ * Behaviour is unchanged. It calls the app-side `/_me` proxy (never the API host
+ * directly — two-tier rule), and on a logged-in response reveals the
+ * `#header-user` element and fills `#header-avatar` with either the user's
+ * avatar image or their initial. A 204 (no session) or any error leaves the
+ * header in its logged-out default. Load this AFTER the header markup is in the
+ * DOM (it is referenced at the end of <body>, same position as the old inline
+ * script).
+ */
+(function () {
+    fetch('/_me')
+        .then(function (r) { return r.status === 204 ? null : r.json(); })
+        .then(function (user) {
+            if (!user) return;
+            var el = document.getElementById('header-user');
+            var av = document.getElementById('header-avatar');
+            if (!el || !av) return;
+            var initial = ((user.display_name || user.email || '?')[0] || '?').toUpperCase();
+            if (user.avatar_url) {
+                var img = document.createElement('img');
+                img.src = user.avatar_url;
+                img.alt = initial;
+                img.className = 'header-avatar__img';
+                av.appendChild(img);
+            } else {
+                var span = document.createElement('span');
+                span.textContent = initial;
+                av.appendChild(span);
+            }
+            el.removeAttribute('hidden');
+        })
+        .catch(function () {});
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -88,31 +88,7 @@
     <script src="/static/js/global-search.js?v={{ app_version }}" defer></script>
     <script src="/static/js/filters.js?v={{ app_version }}" defer></script>
     {% block scripts %}{% endblock %}
-    <script>
-    (function () {
-        fetch('/_me')
-            .then(function (r) { return r.status === 204 ? null : r.json(); })
-            .then(function (user) {
-                if (!user) return;
-                var el = document.getElementById('header-user');
-                var av = document.getElementById('header-avatar');
-                if (!el || !av) return;
-                var initial = ((user.display_name || user.email || '?')[0] || '?').toUpperCase();
-                if (user.avatar_url) {
-                    var img = document.createElement('img');
-                    img.src = user.avatar_url;
-                    img.alt = initial;
-                    img.className = 'header-avatar__img';
-                    av.appendChild(img);
-                } else {
-                    var span = document.createElement('span');
-                    span.textContent = initial;
-                    av.appendChild(span);
-                }
-                el.removeAttribute('hidden');
-            })
-            .catch(function () {});
-    })();
-    </script>
+    {# Header user chip — extracted from an inline IIFE to header-auth.js (F-5, #125). #}
+    <script src="/static/js/header-auth.js?v={{ app_version }}" defer></script>
 </body>
 </html>

--- a/ingestion/connectors/atf_parser.py
+++ b/ingestion/connectors/atf_parser.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Any, Iterable, Iterator
 
 from ingestion.base import LoadStats, RunContext, SourceConnector, SourceManifest
 
@@ -53,9 +53,12 @@ RE_COMPOSITE = re.compile(r"^>>(Q\d+)\s*(.*)$")
 RE_TRANSLATION = re.compile(r"^#tr\.(\w+):\s+(.+)$")
 
 
-def _parse_atf_file(atf_path: Path) -> Iterator[dict]:
-    tablet = None
-    current_surface_type = None
+def _parse_atf_file(atf_path: Path) -> Iterator[dict[str, Any]]:
+    # Heterogeneous accumulator: string fields plus a surfaces dict and three
+    # lists of positional tuples. Typed as dict[str, Any] so the per-key
+    # appends/indexing below type-check; the flush reads entries positionally.
+    tablet: dict[str, Any] | None = None
+    current_surface_type: str | None = None
     current_column = 0
     line_counter = 0
 

--- a/ingestion/connectors/genre_language_junctions.py
+++ b/ingestion/connectors/genre_language_junctions.py
@@ -59,7 +59,7 @@ _TABLE_KEYS = {
 def _decompose_genre(raw_genre: str, genre_ids: dict[str, int]) -> list[tuple]:
     """Return list of (p_number placeholder, genre_id, confidence, is_primary)."""
     parts = [p.strip() for p in raw_genre.split(";") if p.strip()]
-    results = []
+    results: list[tuple] = []
     seen: set[str] = set()
     for i, part in enumerate(parts):
         uncertain = part.rstrip().endswith("?")
@@ -88,7 +88,7 @@ def _decompose_language(raw_lang: str, lang_ids: dict[str, int]) -> list[tuple]:
         "Elamite Egyptian", "Elamite; Egyptian"
     )
     parts = [p.strip().rstrip(",") for p in normalized.split(";") if p.strip()]
-    results = []
+    results: list[tuple] = []
     seen: set[str] = set()
     for part in parts:
         uncertain = part.rstrip().endswith("?")

--- a/ingestion/connectors/oracc_credits.py
+++ b/ingestion/connectors/oracc_credits.py
@@ -270,7 +270,7 @@ class OraccCreditsConnector(SourceConnector):
         for r in rows:
             nn = str(_val(r, "normalized_name", 0))
             if counts[nn] == 1:
-                index[nn] = int(_val(r, "id", 1))  # type: ignore[arg-type]
+                index[nn] = int(_val(r, "id", 1))  # type: ignore[call-overload]
         return index
 
     def _attribute(self, ctx: RunContext) -> None:

--- a/ingestion/connectors/oracc_lemmatizations.py
+++ b/ingestion/connectors/oracc_lemmatizations.py
@@ -254,7 +254,7 @@ def _walk_cdl(nodes, state: dict, out_lemmas: list) -> None:
 
 def _find_corpus_dirs(project: str) -> list[Path]:
     base = _project_base(project)
-    dirs = []
+    dirs: list[Path] = []
     if not base.exists():
         return dirs
     for root, _, filenames in os.walk(base):
@@ -332,7 +332,7 @@ def _build_caches(db, project: str) -> tuple[dict, dict]:
     corpus_dirs = _find_corpus_dirs(project)
     if not corpus_dirs:
         return {}, {}
-    p_numbers = set()
+    p_numbers: set[str] = set()
     for cdir in corpus_dirs:
         p_numbers.update(f.stem for f in cdir.glob("P*.json"))
     if not p_numbers:

--- a/ingestion/runner.py
+++ b/ingestion/runner.py
@@ -143,6 +143,8 @@ def run_connector(
             _git_sha(),
         ),
     ).fetchone()
+    if row is None:
+        raise RuntimeError("INSERT INTO import_runs ... RETURNING id returned no row")
     run_id = row["id"] if isinstance(row, dict) else row[0]
     db.commit()
 

--- a/ops/deploy/provision_verify_session.py
+++ b/ops/deploy/provision_verify_session.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Provision a stable, read-only verify session for post-deploy smoke checks (#280).
+
+Why this exists
+---------------
+Post-deploy authed render checks (the deploy-verifier agent confirming that
+logged-in pages render) used to MINT a short-lived ``user_sessions`` row and then
+DELETE it on every verification run. It reversed cleanly, but every deploy still
+wrote-then-deleted a row in the live production sessions table — noise in an
+auth-critical table, and a small race/footgun if a run aborted mid-way.
+
+This script provisions ONCE a dedicated verify-only user and a single long-lived
+session row. After that, ``smoke-with-auth.sh`` reuses the same token on every
+deploy — no per-run mint, no per-run delete. The verify user is identity-only
+(it owns no annotations, makes no writes); the session it holds is used purely to
+satisfy the auth middleware so authed pages render for the smoke check.
+
+It is **idempotent**: re-running reuses the existing user and the existing
+non-expired session rather than churning the table. It only inserts a new session
+row when none is live, and it never deletes.
+
+Security
+--------
+The raw token is printed exactly once (it is only stored hashed in the DB, same
+as any real session — see auth_service.hash_token). Capture it into the
+``GLINTSTONE_VERIFY_TOKEN`` deploy secret. Anyone holding it can view the same
+pages a logged-in reader sees — nothing more (the user performs no writes). Rotate
+by re-running with ``--rotate``.
+
+Usage
+-----
+    # First-time provision (prints the token to store as a secret):
+    python -m ops.deploy.provision_verify_session
+
+    # Force a fresh token (revokes the old verify session, mints one new one):
+    python -m ops.deploy.provision_verify_session --rotate
+
+    # Custom lifetime (default 365 days):
+    python -m ops.deploy.provision_verify_session --days 90
+
+Run it on the VPS (or anywhere with DATABASE_URL pointing at prod), as the app
+DB user — it needs only the DML already granted to ``glintstone`` on ``users`` and
+``user_sessions``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Allow running as a plain script (python ops/deploy/provision_verify_session.py)
+# as well as a module — mirror the path bootstrap used by scripts/.
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from api.services.auth_service import generate_session_token, hash_token  # noqa: E402
+from core.database import close_pool, get_connection, init_pool  # noqa: E402
+
+VERIFY_EMAIL = "verify@glintstone.org"
+VERIFY_DISPLAY_NAME = "Deploy Verify (read-only)"
+
+
+def _ensure_verify_user(conn) -> str:
+    """Return the verify user's id, creating the row if absent. Idempotent."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO users (email, display_name, email_verified_at)
+            VALUES (%(email)s, %(name)s, now())
+            ON CONFLICT (email) DO UPDATE SET display_name = EXCLUDED.display_name
+            RETURNING id
+            """,
+            {"email": VERIFY_EMAIL, "name": VERIFY_DISPLAY_NAME},
+        )
+        row = cur.fetchone()
+        return str(row["id"])
+
+
+def _existing_live_session(conn, user_id: str) -> bool:
+    """True if the verify user already has a non-expired session row."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+            FROM user_sessions
+            WHERE user_id = %(uid)s AND expires_at > now()
+            LIMIT 1
+            """,
+            {"uid": user_id},
+        )
+        return cur.fetchone() is not None
+
+
+def _revoke_verify_sessions(conn, user_id: str) -> int:
+    """Delete all sessions for the verify user (used by --rotate). Returns count."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM user_sessions WHERE user_id = %(uid)s",
+            {"uid": user_id},
+        )
+        return cur.rowcount
+
+
+def _mint_verify_session(conn, user_id: str, days: int) -> str:
+    """Insert a single long-lived session row, return the RAW token (printed once)."""
+    raw = generate_session_token()
+    token_hash = hash_token(raw)
+    expires_at = datetime.now(timezone.utc) + timedelta(days=days)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO user_sessions (user_id, token_hash, expires_at, user_agent)
+            VALUES (%(uid)s, %(hash)s, %(exp)s, %(ua)s)
+            """,
+            {
+                "uid": user_id,
+                "hash": token_hash,
+                "exp": expires_at,
+                "ua": "glintstone-deploy-verify",
+            },
+        )
+    return raw
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rotate",
+        action="store_true",
+        help="Revoke existing verify sessions and mint a fresh token.",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=365,
+        help="Session lifetime in days (default 365).",
+    )
+    args = parser.parse_args()
+
+    init_pool(min_size=0, max_size=2, timeout=30.0)
+    try:
+        with get_connection() as conn:
+            user_id = _ensure_verify_user(conn)
+
+            if args.rotate:
+                revoked = _revoke_verify_sessions(conn, user_id)
+                raw = _mint_verify_session(conn, user_id, args.days)
+                conn.commit()
+                print(f"# Rotated verify session (revoked {revoked} old).")
+                _print_token(raw, args.days)
+                return 0
+
+            if _existing_live_session(conn, user_id):
+                conn.rollback()
+                print(
+                    "# A live verify session already exists — no new row minted.\n"
+                    "# The previously-printed token is still valid. Use --rotate to\n"
+                    "# replace it (e.g. if the secret was lost or leaked).",
+                    file=sys.stderr,
+                )
+                return 0
+
+            raw = _mint_verify_session(conn, user_id, args.days)
+            conn.commit()
+            print("# Provisioned a new verify session.")
+            _print_token(raw, args.days)
+            return 0
+    finally:
+        close_pool()
+
+
+def _print_token(raw: str, days: int) -> None:
+    print(
+        f"# Store this as the GLINTSTONE_VERIFY_TOKEN deploy secret (valid {days} days):"
+    )
+    print(raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/deploy/smoke-with-auth.sh
+++ b/ops/deploy/smoke-with-auth.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# smoke-with-auth.sh — post-deploy authed render check that does NOT mint or
+# delete production user_sessions rows (#280).
+#
+# Background
+#   Authed post-deploy checks used to create a throwaway session row and delete
+#   it afterwards, touching the live sessions table on every deploy. Instead this
+#   script reuses a single, pre-provisioned read-only verify session (see
+#   provision_verify_session.py) by sending its token as the `session_token`
+#   cookie. The only write it causes server-side is a `last_seen_at` UPDATE
+#   (a touch) on that one stable row — never an INSERT, never a DELETE.
+#
+# What it checks
+#   1. /_me returns HTTP 200 with a JSON body → the session is recognised, i.e.
+#      authed pages will render as logged-in (the thing we actually want to
+#      verify after a deploy). A 204 means the token was rejected (logged-out).
+#   2. Optionally, a target authed page renders 200 and contains an expected
+#      logged-in marker.
+#
+# Usage
+#   GLINTSTONE_VERIFY_TOKEN=<raw-token> ./ops/deploy/smoke-with-auth.sh \
+#       [BASE_URL] [AUTHED_PATH] [EXPECT_SUBSTRING]
+#
+#   BASE_URL          default https://glintstone.org
+#   AUTHED_PATH       optional authed page to additionally fetch (e.g. /account)
+#   EXPECT_SUBSTRING  optional string that must appear in AUTHED_PATH's HTML
+#                     (default: header-user — the logged-in chip id)
+#
+# Exit codes
+#   0  authed render check passed
+#   1  token rejected / page failed / missing token
+
+set -euo pipefail
+
+BASE_URL="${1:-https://glintstone.org}"
+AUTHED_PATH="${2:-}"
+EXPECT_SUBSTRING="${3:-header-user}"
+
+if [ -z "${GLINTSTONE_VERIFY_TOKEN:-}" ]; then
+    echo "::error::GLINTSTONE_VERIFY_TOKEN is not set." >&2
+    echo "Provision one with: python -m ops.deploy.provision_verify_session" >&2
+    exit 1
+fi
+
+COOKIE="session_token=${GLINTSTONE_VERIFY_TOKEN}"
+
+# --- 1. /_me must recognise the verify session (200, not 204) ---
+echo "Checking authed session against ${BASE_URL}/_me ..."
+me_status="$(curl -fsS -o /tmp/gs_verify_me.json -w '%{http_code}' \
+    --max-time 10 \
+    --cookie "$COOKIE" \
+    "${BASE_URL}/_me" || true)"
+
+if [ "$me_status" = "204" ]; then
+    echo "::error::/_me returned 204 — the verify token was NOT recognised." >&2
+    echo "The session may have expired; re-run provision_verify_session.py --rotate." >&2
+    exit 1
+fi
+
+if [ "$me_status" != "200" ]; then
+    echo "::error::/_me returned HTTP $me_status (expected 200)." >&2
+    exit 1
+fi
+
+echo "OK: /_me recognised the verify session (HTTP 200, logged-in)."
+
+# --- 2. Optional: a specific authed page renders with the logged-in marker ---
+if [ -n "$AUTHED_PATH" ]; then
+    echo "Checking authed page ${BASE_URL}${AUTHED_PATH} ..."
+    page_status="$(curl -fsS -o /tmp/gs_verify_page.html -w '%{http_code}' \
+        --max-time 10 \
+        --cookie "$COOKIE" \
+        "${BASE_URL}${AUTHED_PATH}" || true)"
+
+    if [ "$page_status" != "200" ]; then
+        echo "::error::${AUTHED_PATH} returned HTTP $page_status (expected 200)." >&2
+        exit 1
+    fi
+
+    if ! grep -q "$EXPECT_SUBSTRING" /tmp/gs_verify_page.html; then
+        echo "::error::${AUTHED_PATH} did not contain expected marker '$EXPECT_SUBSTRING'." >&2
+        exit 1
+    fi
+    echo "OK: ${AUTHED_PATH} rendered logged-in (found '$EXPECT_SUBSTRING')."
+fi
+
+echo "SMOKE_AUTH_OK"

--- a/tests/js/era_suffix.test.mjs
+++ b/tests/js/era_suffix.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * #386 — regression harness for the timeline era-suffix formatters.
+ *
+ * Two near-identical functions render a `period_canon` year as a human era
+ * label, and the dual-era convention behind them (#332) is subtle and easy to
+ * invert by accident:
+ *
+ *   period_canon stores BCE years as POSITIVE integers (2100 → "2100 BCE")
+ *   and the few genuinely-CE years as NEGATIVE integers (-224 → "224 CE").
+ *   So the era suffix is the INVERSE of the sign.
+ *
+ *   - app/static/js/transmission-timeline.js   → function formatYear(year)
+ *   - app/static/js/lemma-period-timeline.js   → function lptFormatYear(year)
+ *
+ * These are plain `<script>` globals (no module system, no build step), so the
+ * harness reads each source file, lifts the named function out by its source
+ * text, and evaluates it in isolation. That means we test the *actually shipped*
+ * logic — not a hand-copied duplicate that could itself drift.
+ *
+ * Run: `node --test tests/js/` (no npm install — uses the built-in test runner).
+ * Wired into CI as a dedicated step in .github/workflows/test.yml.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Lift a top-level `function NAME(...) { ... }` out of a source file and return
+ * it as a callable, balancing braces so we capture the whole body.
+ */
+function extractFunction(relPath, name) {
+  const src = readFileSync(join(ROOT, relPath), 'utf8');
+  const signature = `function ${name}(`;
+  const start = src.indexOf(signature);
+  assert.notStrictEqual(
+    start,
+    -1,
+    `${name} not found in ${relPath} — was it renamed? Update this harness.`,
+  );
+  // Walk from the first '{' after the signature, balancing braces.
+  let i = src.indexOf('{', start);
+  assert.notStrictEqual(i, -1, `no opening brace for ${name} in ${relPath}`);
+  let depth = 0;
+  let end = -1;
+  for (; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.notStrictEqual(end, -1, `unbalanced braces for ${name} in ${relPath}`);
+  const fnSource = src.slice(start, end);
+  // eslint-disable-next-line no-new-func
+  return new Function(`${fnSource}; return ${name};`)();
+}
+
+const formatYear = extractFunction(
+  'app/static/js/transmission-timeline.js',
+  'formatYear',
+);
+const lptFormatYear = extractFunction(
+  'app/static/js/lemma-period-timeline.js',
+  'lptFormatYear',
+);
+
+// The two formatters must agree on every case — that's the whole point of
+// having a shared convention. Run the identical table against both.
+const formatters = [
+  ['transmission-timeline:formatYear', formatYear],
+  ['lemma-period-timeline:lptFormatYear', lptFormatYear],
+];
+
+for (const [label, fmt] of formatters) {
+  test(`${label}: positive years are BCE`, () => {
+    assert.equal(fmt(2100), '2100 BCE'); // Ur III
+    assert.equal(fmt(1), '1 BCE');
+    assert.equal(fmt(3500), '3500 BCE');
+  });
+
+  test(`${label}: negative years are CE (sign inverted, no minus sign)`, () => {
+    assert.equal(fmt(-224), '224 CE'); // end of Parthian
+    assert.equal(fmt(-1), '1 CE');
+    // The minus sign must be stripped, not rendered.
+    assert.ok(!fmt(-224).includes('-'), 'CE label must not show a minus sign');
+  });
+
+  test(`${label}: year zero is the bare "0"`, () => {
+    assert.equal(fmt(0), '0');
+  });
+
+  test(`${label}: the era suffix never disagrees with the sign`, () => {
+    assert.ok(fmt(500).endsWith('BCE'));
+    assert.ok(fmt(-500).endsWith('CE'));
+  });
+}

--- a/tests/unit/agent/test_line_suggestion_persist.py
+++ b/tests/unit/agent/test_line_suggestion_persist.py
@@ -1,0 +1,204 @@
+"""Persist / read-back coverage for ``do_suggest_line_translation`` (#216).
+
+Why this exists
+---------------
+#215 surfaced a class of bug that pytest could not catch: the agent_outputs
+call sites drifted on a keyword name (``raw_output`` vs ``output_text``) and the
+only thing that flagged it was mypy. The agentic line-suggestion feature (#109)
+had *zero* tests, so a future rename of the persisted-column keyword, or a change
+to the JSON shape written on the way in / read on the way out, would pass the
+suite silently and only blow up against a live database.
+
+These tests pin the **persist → read-back round-trip** of
+``do_suggest_line_translation`` without a database or an Anthropic call:
+
+1. On a cache *miss* the function persists via ``agent_outputs.insert`` — we
+   capture the exact keyword arguments it passes (this fails loudly if the
+   ``output_text=`` keyword is renamed, the #215 failure mode).
+2. On a cache *hit* the function reads ``persisted.output_text`` back, JSON-loads
+   it, and reconstructs a ``LineSuggestionPayload``. We feed it the very bytes
+   captured in step 1, proving the written shape is the shape the reader expects.
+
+If the persisted JSON shape and the read-back parser ever drift apart, the
+round-trip test fails in pytest — not just under mypy, and not only in prod.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+
+from api.services import agent_service
+from core.agent.agent_outputs import PersistedOutput
+from core.schemas.envelope import LineSuggestionPayload
+
+
+class _FakeConn:
+    """Stand-in for a psycopg connection. The service never touches it directly
+    in these tests — every DB seam (insert / find_fresh / fact assembly) is
+    monkeypatched — but the signature requires *something* to pass through."""
+
+
+def _persisted_from(output_text: str) -> PersistedOutput:
+    """Build a PersistedOutput exactly as ``find_fresh`` would return it."""
+    return PersistedOutput(
+        id=1,
+        interaction_id=None,
+        output_type="line_suggestion",
+        target_type="line",
+        target_id="P000001:obverse:1:",
+        focus="suggest",
+        model="claude-test",
+        prompt_version="suggest-line.v1",
+        output_text=output_text,
+        citations=[],
+        source_run_ids=[],
+        best_guess_flag=False,
+        generated_at=datetime.now(UTC),
+    )
+
+
+def test_read_back_reconstructs_payload_from_cache(monkeypatch):
+    """Cache hit: the persisted JSON is read from ``output_text`` and rebuilt
+    into a ``LineSuggestionPayload`` with the original fields intact."""
+    payload = LineSuggestionPayload(
+        line_id=42,
+        atf="lugal-e",
+        language="Sumerian",
+        language_supported=True,
+        missing_layers=["morphology"],
+        model="claude-test",
+        prompt_version="suggest-line.v1",
+    )
+    cached_text = json.dumps(
+        {"summary": "Line 1: the king", "data": payload.model_dump()}
+    )
+
+    monkeypatch.setattr(
+        agent_service.agent_outputs,
+        "find_fresh",
+        lambda conn, **kw: _persisted_from(cached_text),
+    )
+
+    resp = agent_service.do_suggest_line_translation(
+        _FakeConn(),  # type: ignore[arg-type]
+        p_number="P000001",
+        surface_name="obverse",
+        line_number="1",
+        interaction_id_str="int-1",
+    )
+
+    assert resp.summary == "Line 1: the king"
+    assert resp.data.line_id == 42
+    assert resp.data.atf == "lugal-e"
+    assert resp.data.language == "Sumerian"
+    assert resp.data.missing_layers == ["morphology"]
+    # Cached responses are labelled as a cached synthesis source.
+    assert any(s.method == "cached-synthesis" for s in resp.sources)
+
+
+def test_persisted_text_round_trips_through_read_back(monkeypatch):
+    """The core anti-drift guarantee.
+
+    Drive a cache *miss* so the function builds a payload and persists it; capture
+    the exact ``output_text`` keyword it writes; then feed that captured text back
+    through the read-back path and assert the payload survives the round-trip.
+
+    This is the #215 failure class: if persist writes one keyword/shape and
+    read-back expects another, this test fails in pytest.
+    """
+    captured: dict[str, object] = {}
+
+    def _fake_insert(conn, **kwargs):
+        # Fails loudly if the persist call site drops/renames ``output_text``
+        # (the #215 ``raw_output`` regression).
+        assert "output_text" in kwargs, "persist must pass output_text="
+        captured["output_text"] = kwargs["output_text"]
+        captured["output_type"] = kwargs["output_type"]
+        captured["target_type"] = kwargs["target_type"]
+        return 1
+
+    # Empty fact bundle → the function returns a "line not found" payload and
+    # skips the live Anthropic call, but we still want to assert persistence
+    # semantics, so drive the supported-language synthesis path instead by
+    # stubbing the seams it touches.
+    from core.agent import fact_assembly as _fa
+
+    class _Bundle:
+        line_id = 7
+        atf_text = "e2-gal"
+        language = "Sumerian"
+        dialect = None
+        is_mixed_language = False
+        language_shift_position = None
+        language_supported = True
+        missing_layers: list[str] = []
+        context_variant = "a"
+
+    monkeypatch.setattr(_fa, "assemble_line_facts", lambda conn, **kw: _Bundle())
+    monkeypatch.setattr(
+        agent_service.fact_assembly,
+        "assemble_line_facts",
+        lambda conn, **kw: _Bundle(),
+    )
+
+    class _FakeAnthropic:
+        model = "claude-test"
+
+    monkeypatch.setattr(agent_service, "_get_anthropic", lambda: _FakeAnthropic())
+
+    # synthesize returns a result whose .text is parsed as JSON; an empty
+    # object yields no suggestions (best-guess path) but still persists.
+    class _Result:
+        text = "{}"
+
+    monkeypatch.setattr(
+        agent_service, "synthesize_line_suggestion", lambda *a, **kw: _Result()
+    )
+
+    # First call: cache miss → persist.
+    monkeypatch.setattr(
+        agent_service.agent_outputs, "find_fresh", lambda conn, **kw: None
+    )
+    monkeypatch.setattr(agent_service.agent_outputs, "insert", _fake_insert)
+
+    first = agent_service.do_suggest_line_translation(
+        _FakeConn(),  # type: ignore[arg-type]
+        p_number="P000001",
+        surface_name="obverse",
+        line_number="1",
+        interaction_id_str="int-1",
+    )
+
+    # Persist happened with the right keyword and the right column shape.
+    assert "output_text" in captured
+    assert captured["output_type"] == "line_suggestion"
+    persisted_text = captured["output_text"]
+    assert isinstance(persisted_text, str)
+
+    # The persisted JSON must carry the {"summary", "data"} envelope the
+    # read-back path expects.
+    decoded = json.loads(persisted_text)
+    assert "summary" in decoded
+    assert "data" in decoded
+
+    # Now feed the captured text back through the read-back (cache-hit) path and
+    # assert the payload survives the round-trip — same atf, same line_id.
+    monkeypatch.setattr(
+        agent_service.agent_outputs,
+        "find_fresh",
+        lambda conn, **kw: _persisted_from(persisted_text),
+    )
+
+    second = agent_service.do_suggest_line_translation(
+        _FakeConn(),  # type: ignore[arg-type]
+        p_number="P000001",
+        surface_name="obverse",
+        line_number="1",
+        interaction_id_str="int-2",
+    )
+
+    assert second.data.atf == first.data.atf == "e2-gal"
+    assert second.data.line_id == first.data.line_id == 7
+    assert second.summary == first.summary

--- a/tests/web/test_header_auth_extraction.py
+++ b/tests/web/test_header_auth_extraction.py
@@ -1,0 +1,85 @@
+"""#125 — verify the header auth script was extracted to header-auth.js (F-5).
+
+The audit finding was that the auth IIFE lived inline in base.html, tightly
+coupled to the header markup and impossible to cache or lint on its own. These
+tests pin the extraction so it can't silently regress back inline, and confirm
+the external file is actually served and still wired to the header elements.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class _StubTransport:
+    def get(self, path, params=None, token=None):
+        return {}
+
+    def post(self, path, json=None, token=None):
+        return {}
+
+    def put(self, path, json=None, token=None):
+        return {}
+
+    def patch(self, path, json=None, token=None):
+        return None
+
+    def delete(self, path, token=None):
+        return None
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from core import database
+
+    monkeypatch.setattr(database, "init_pool", lambda *a, **kw: None)
+    monkeypatch.setattr(database, "close_pool", lambda *a, **kw: None)
+
+    from app import main as app_main
+    from app.api_client import GlintstoneAPI
+    from app.transports import HttpxTransport
+
+    monkeypatch.setattr(HttpxTransport, "__init__", lambda self, **kw: None)
+    monkeypatch.setattr(HttpxTransport, "close", lambda self: None)
+
+    fake_api = GlintstoneAPI(_StubTransport())
+    with TestClient(app_main.app, cookies={"session_token": "test-token"}) as c:
+        c.app.state.api = fake_api
+        yield c
+
+
+def test_header_auth_script_is_referenced(client):
+    """A rendered page references the extracted header-auth.js file."""
+    r = client.get("/")
+    # Home may redirect or render; follow to a 200 HTML page.
+    if r.status_code not in (200,):
+        pytest.skip(f"home returned {r.status_code}")
+    assert "/static/js/header-auth.js" in r.text
+
+
+def test_auth_iife_not_inlined(client):
+    """The inline fetch('/_me') IIFE must no longer live in the page source."""
+    r = client.get("/")
+    if r.status_code != 200:
+        pytest.skip(f"home returned {r.status_code}")
+    # The old inline marker — an inline fetch to the session proxy — is gone.
+    assert "fetch('/_me')" not in r.text
+
+
+def test_header_auth_file_is_served(client):
+    """The static file exists and is served with its auth logic intact."""
+    r = client.get("/static/js/header-auth.js")
+    assert r.status_code == 200
+    body = r.text
+    assert "/_me" in body
+    assert "header-user" in body
+    assert "header-avatar" in body

--- a/tests/web/test_prd017_routes.py
+++ b/tests/web/test_prd017_routes.py
@@ -1,0 +1,186 @@
+"""#114 — unit coverage for the PRD-017 web page routes (no live DB).
+
+Audit finding 3b: integration tests can't reach the VPS Postgres from CI, so the
+PRD-017 pages — compositions, dictionary, scholars, and the dashboard/home — had
+no automated guard. A regression in any of these routes (a renamed API-client
+method, a template context key drop, a 500 on an empty envelope) would ship
+unnoticed.
+
+These tests render each route through the real app + real GlintstoneAPI client,
+with the HTTP transport replaced by an in-memory fixture map. The transport is
+the seam that would normally hit the API (and through it, Postgres) — stubbing it
+gives us true unit coverage of the route → client → template path with zero DB.
+
+Scope note: per the chores-batch-2 split, the /tablets-list and provenience
+routes are owned by concurrent PRs and are intentionally NOT covered here.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# ── Fixtures shaped like the API's JSON envelopes ──────────────────────────────
+
+_COMPOSITE = {
+    "q_number": "Q000001",
+    "designation": "Gilgamesh",
+    "language": "Akkadian",
+    "genre": "literary",
+    "period": "Old Babylonian",
+    "exemplar_count": 42,
+}
+
+_COMPOSITES_PAGE = {
+    "items": [_COMPOSITE],
+    "total": 1,
+    "page": 1,
+    "per_page": 50,
+    "total_pages": 1,
+}
+
+_KPI = {
+    "top_periods": [{"label": "Ur III", "count": 10}],
+    "top_genres": [{"label": "literary", "count": 8}],
+    "top_languages": [{"label": "Sumerian", "count": 12}],
+}
+
+_DICTIONARY_PAGE = {
+    "items": [
+        {"lemma_id": 1, "lemma": "lugal", "guide_word": "king", "attestations": 99}
+    ],
+    "total": 1,
+    "page": 1,
+    "per_page": 50,
+    "total_pages": 1,
+}
+
+_SCHOLARS_PAGE = {"items": [], "total": 7, "page": 1, "per_page": 1, "total_pages": 7}
+
+
+class _FixtureTransport:
+    """Maps API paths to canned JSON. Anything unmapped returns an empty dict,
+    which the GlintstoneAPI client degrades to an empty Page / {} envelope."""
+
+    def __init__(self):
+        self._fixtures = {
+            "/composites": _COMPOSITES_PAGE,
+            "/dictionary": _DICTIONARY_PAGE,
+            "/scholars": _SCHOLARS_PAGE,
+            "/kpi": _KPI,
+            "/coverage-gaps": {"items": []},
+            "/auth/me": {},
+            "/users/me/saved-items": [],
+            "/periods": {"items": []},
+        }
+
+    def get(self, path, params=None, token=None):
+        # Exact match first, then prefix match for nested resource paths.
+        if path in self._fixtures:
+            return self._fixtures[path]
+        for key, val in self._fixtures.items():
+            if path.startswith(key):
+                return val
+        return {}
+
+    def post(self, path, json=None, token=None):
+        return {}
+
+    def put(self, path, json=None, token=None):
+        return {}
+
+    def patch(self, path, json=None, token=None):
+        return None
+
+    def delete(self, path, token=None):
+        return None
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from core import database
+
+    monkeypatch.setattr(database, "init_pool", lambda *a, **kw: None)
+    monkeypatch.setattr(database, "close_pool", lambda *a, **kw: None)
+
+    from app import main as app_main
+    from app.api_client import GlintstoneAPI
+    from app.transports import HttpxTransport
+
+    monkeypatch.setattr(HttpxTransport, "__init__", lambda self, **kw: None)
+    monkeypatch.setattr(HttpxTransport, "close", lambda self: None)
+
+    fake_api = GlintstoneAPI(_FixtureTransport())
+    with TestClient(app_main.app, cookies={"session_token": "test-token"}) as c:
+        c.app.state.api = fake_api
+        yield c
+
+
+# ── Dashboard / home ───────────────────────────────────────────────────────────
+
+
+def test_homepage_renders(client):
+    r = client.get("/")
+    assert r.status_code == 200
+    # Canon section is fed by list_composites — the designation should appear.
+    assert "Gilgamesh" in r.text
+
+
+def test_homepage_survives_empty_kpi(client):
+    """A missing KPI envelope must not 500 the dashboard."""
+    client.app.state.api._t._fixtures["/kpi"] = {}
+    r = client.get("/")
+    assert r.status_code == 200
+
+
+# ── Compositions ───────────────────────────────────────────────────────────────
+
+
+def test_compositions_list_renders(client):
+    r = client.get("/compositions")
+    assert r.status_code == 200
+    assert "Gilgamesh" in r.text
+
+
+def test_compositions_list_with_filters(client):
+    """Client-side lang/genre/period filters must not error."""
+    r = client.get("/compositions?lang=Akkadian&genre=literary")
+    assert r.status_code == 200
+
+
+def test_compositions_empty_envelope(client):
+    """An empty /composites envelope renders an empty page, not a 500."""
+    client.app.state.api._t._fixtures["/composites"] = {"items": [], "total": 0}
+    r = client.get("/compositions")
+    assert r.status_code == 200
+
+
+# ── Dictionary ─────────────────────────────────────────────────────────────────
+
+
+def test_dictionary_index_renders(client):
+    r = client.get("/dictionary")
+    assert r.status_code == 200
+
+
+def test_dictionary_invalid_level_defaults(client):
+    """An unknown ?level= is coerced to 'lemmas' rather than 500-ing."""
+    r = client.get("/dictionary?level=bogus")
+    assert r.status_code == 200
+
+
+# ── Scholars ───────────────────────────────────────────────────────────────────
+
+
+def test_scholars_list_renders(client):
+    r = client.get("/scholars")
+    assert r.status_code == 200


### PR DESCRIPTION
Batched low-conflict cleanup (chores-batch-2). Six items; #129 intentionally left open.

## What's in
- **#114** — web route unit tests (mocked DB transport) for the PRD-017 pages: compositions, dictionary, scholars, dashboard. Renders each route through the real app + `GlintstoneAPI` with an in-memory fixture transport — true unit coverage with zero Postgres. (`tests/web/test_prd017_routes.py`)
- **#125** — extracted the inline auth IIFE from `base.html` into `app/static/js/header-auth.js` (F-5). Behaviour unchanged (loaded `defer` at end of `<body>`). Guarded by `tests/web/test_header_auth_extraction.py`.
- **#137** — type-annotated `ingestion/` (19 mypy errors → 0 across 5 files) and added `ingestion/` to the CI mypy scope in `test.yml`. Kills the recurring "pre-existing mypy errors in ingestion/" noise at the source.
- **#216** — persist/read-back test for `do_suggest_line_translation`, pinning the `agent_outputs` `output_text` keyword + JSON shape end-to-end. This is the #215 call-site-drift class that previously only mypy caught. (`tests/unit/agent/test_line_suggestion_persist.py`)
- **#280** — deploy verify tooling: `ops/deploy/provision_verify_session.py` (one-time, idempotent read-only verify session) + `ops/deploy/smoke-with-auth.sh` reuse one stable session so authed post-deploy checks stop minting/deleting prod `user_sessions` rows.
- **#386** — Node built-in test harness for the timeline era-suffix formatters (BCE+/CE-), wired into CI; guards the #332 dual-era logic. Loads the actual shipped functions, no npm. (`tests/js/era_suffix.test.mjs`)

## Left open
- **#129** (per-surface image serving) — couples with in-flight TabletViewer/image work (`image_width/height` population + viewer scaling); exceeds this batch's low-conflict scope. Left `todo`.

## Gate (run locally)
- `ruff check .` + `ruff format --check .` — clean
- `mypy api/ app/ core/ mcp/ ingestion/ --ignore-missing-imports` — clean (131 files)
- `pytest tests/` — 375 passed, 40 skipped (DB integration, as in CI)
- `node --test 'tests/js/*.test.mjs'` — 8/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)