### PR TITLE
feat(map): proportional-symbol find-spot maps (#197 #198 #199)

### DIFF
--- a/app/api_client.py
+++ b/app/api_client.py
@@ -145,6 +145,25 @@ class GlintstoneAPI:
         except Exception:
             return []
 
+    def get_site_coords(self) -> dict:
+        """Geolocated find-spots for the map layer (#197–#199 / #319).
+
+        Returns ``{"sites": [{ancient_name, modern_name, latitude, longitude,
+        pleiades_id, region, tablet_count}, ...], "uncertain": {"tablet_count":
+        N}}`` — one entry per geocoded ancient site, ordered busiest-first, plus
+        the aggregate count of uncertain-provenance tablets that are never
+        pinned (#313). Degrades to an empty, well-formed envelope on any
+        failure so the map view falls back to its caption-only state rather
+        than 500-ing the page.
+        """
+        try:
+            result = self._t.get("/proveniences/coords")
+            if isinstance(result, dict) and "sites" in result:
+                return result
+        except Exception:
+            pass
+        return {"sites": [], "uncertain": {"tablet_count": 0}}
+
     def get_artifact_debug(self, p_number: str) -> dict:
         try:
             return self._t.get(f"/artifacts/{p_number}/debug")  # type: ignore[return-value]

--- a/app/corpus_map.py
+++ b/app/corpus_map.py
@@ -1,0 +1,167 @@
+"""Corpus map projection — proportional-symbol find-spot maps (#197–#199).
+
+The map viz is a deliberately *schematic* proportional-symbol map (Tufte/Victor,
+from the #313 all-artifacts critique): circles sized by tablet count, placed on a
+plain Mesopotamia base (the two rivers as a schematic hint, no heavy basemap
+chartjunk). We do the geographic projection **here, server-side**, so:
+
+  * the SVG is render-proven without JS (the no-JS rule — pins are real <a> links),
+  * the math is unit-tested at the gate (pytest), not buried in a template, and
+  * all three consumers — the /tablets atlas map (#197), the composition map
+    (#198) and the tablet mini-map (#199) — share one honest projection.
+
+Projection: a plain equirectangular (lat/lon → linear x/y) over a fixed
+Mesopotamia bounding box. At this latitude band (~31–40°N) the longitude
+compression is mild and a schematic base does not pretend to survey accuracy, so
+an equirectangular projection is the honest, dependency-free choice — no Leaflet,
+no tiles, no projection library.
+
+Sizing: circle *area* is proportional to tablet count (radius ∝ √count), the
+correct encoding for a proportional-symbol map — area, not radius, reads as
+quantity. Radii are clamped to a legible [MIN, MAX] range.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# Fixed schematic viewBox. The map is drawn in this coordinate space and scaled
+# to fit its container by the SVG viewBox — so callers pick display size in CSS,
+# not here.
+VIEW_W = 1000.0
+VIEW_H = 760.0
+# Inner padding so edge pins (and their labels) are not clipped.
+PAD_X = 70.0
+PAD_Y = 60.0
+
+# Mesopotamia bounding box (decimal degrees). Chosen to comfortably contain every
+# geocoded find-spot in the corpus — from Anatolia / Ḫattusa (~40°N, ~34.6°E) in
+# the NW to Susa / Elam (~32°N, ~48.3°E) and the southern Sumerian cities
+# (~30.9°N). A fixed box (not data-derived) keeps the base map stable across the
+# three views and across filter changes, so a site never visually "jumps".
+LAT_MIN, LAT_MAX = 29.5, 40.5  # south → north
+LON_MIN, LON_MAX = 33.5, 49.5  # west → east
+
+# Proportional-symbol radius range, in viewBox units.
+R_MIN = 5.0
+R_MAX = 46.0
+
+
+@dataclass(frozen=True)
+class Pin:
+    """One placed find-spot, ready to draw."""
+
+    ancient_name: str
+    modern_name: str | None
+    region: str | None
+    tablet_count: int
+    x: float  # viewBox x
+    y: float  # viewBox y
+    r: float  # circle radius (area ∝ count)
+    in_bounds: bool  # False when coords fell outside the schematic box
+
+
+def project(latitude: float, longitude: float) -> tuple[float, float, bool]:
+    """Project (lat, lon) → (x, y) in the schematic viewBox.
+
+    Returns ``(x, y, in_bounds)``. Out-of-box coordinates are clamped to the
+    drawable area (so nothing renders off-canvas) and flagged ``in_bounds=False``
+    so the caller can omit them honestly rather than planting a misleading pin.
+    """
+    in_bounds = LAT_MIN <= latitude <= LAT_MAX and LON_MIN <= longitude <= LON_MAX
+    # Longitude → x (west to east, left to right).
+    fx = (longitude - LON_MIN) / (LON_MAX - LON_MIN)
+    # Latitude → y (north at top, so invert: higher latitude = smaller y).
+    fy = (LAT_MAX - latitude) / (LAT_MAX - LAT_MIN)
+    fx = min(max(fx, 0.0), 1.0)
+    fy = min(max(fy, 0.0), 1.0)
+    x = PAD_X + fx * (VIEW_W - 2 * PAD_X)
+    y = PAD_Y + fy * (VIEW_H - 2 * PAD_Y)
+    return x, y, in_bounds
+
+
+def _radius(count: int, max_count: int) -> float:
+    """Radius such that circle *area* is ∝ count (radius ∝ √count), clamped."""
+    if max_count <= 0 or count <= 0:
+        return R_MIN
+    frac = math.sqrt(count) / math.sqrt(max_count)
+    return R_MIN + frac * (R_MAX - R_MIN)
+
+
+def build_pins(sites: list[dict]) -> list[Pin]:
+    """Turn coords-API site rows into draw-ready, projected, sized pins.
+
+    ``sites`` is the ``sites`` list from GET /proveniences/coords (or any list of
+    dicts carrying ``ancient_name / latitude / longitude / tablet_count`` and
+    optionally ``modern_name / region``). Rows missing usable coordinates are
+    dropped (they simply do not pin — the coverage caption owns that gap).
+    Returned pins are sorted largest-circle-last so big symbols do not occlude
+    small ones in normal SVG paint order — wait, we want the opposite: draw
+    *large first* so small pins sit on top and stay clickable. Sorted ascending
+    by radius, then reversed at draw time would flip that; instead we sort
+    descending by count here and the template paints in order (big → small).
+    """
+    placed: list[Pin] = []
+    counts = [
+        int(s.get("tablet_count") or 0)
+        for s in sites
+        if s.get("latitude") is not None and s.get("longitude") is not None
+    ]
+    max_count = max(counts) if counts else 0
+    for s in sites:
+        lat, lon = s.get("latitude"), s.get("longitude")
+        if lat is None or lon is None:
+            continue
+        try:
+            latf, lonf = float(lat), float(lon)
+        except (TypeError, ValueError):
+            continue
+        x, y, in_bounds = project(latf, lonf)
+        count = int(s.get("tablet_count") or 0)
+        placed.append(
+            Pin(
+                ancient_name=s.get("ancient_name") or "",
+                modern_name=s.get("modern_name"),
+                region=s.get("region"),
+                tablet_count=count,
+                x=round(x, 1),
+                y=round(y, 1),
+                r=round(_radius(count, max_count), 1),
+                in_bounds=in_bounds,
+            )
+        )
+    # Paint largest first so the smallest stay on top and clickable.
+    placed.sort(key=lambda p: p.tablet_count, reverse=True)
+    return placed
+
+
+# A single fixed marker radius for the one-tablet mini-map (#199), where "how
+# many tablets" is always one and proportional sizing would be meaningless.
+SINGLE_PIN_R = 12.0
+
+
+def build_single_pin(site: dict) -> Pin | None:
+    """Project one find-spot to a single fixed-size marker (tablet mini-map).
+
+    Returns ``None`` when the site has no usable coordinates (the caller then
+    renders no map — the provenience name still shows elsewhere).
+    """
+    lat, lon = site.get("latitude"), site.get("longitude")
+    if lat is None or lon is None:
+        return None
+    try:
+        latf, lonf = float(lat), float(lon)
+    except (TypeError, ValueError):
+        return None
+    x, y, in_bounds = project(latf, lonf)
+    return Pin(
+        ancient_name=site.get("ancient_name") or "",
+        modern_name=site.get("modern_name"),
+        region=site.get("region"),
+        tablet_count=int(site.get("tablet_count") or 0),
+        x=round(x, 1),
+        y=round(y, 1),
+        r=SINGLE_PIN_R,
+        in_bounds=in_bounds,
+    )

--- a/app/routes/compositions.py
+++ b/app/routes/compositions.py
@@ -3,6 +3,10 @@
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 
+from app.corpus_map import VIEW_H as MAP_VIEW_H
+from app.corpus_map import VIEW_W as MAP_VIEW_W
+from app.corpus_map import build_pins
+
 router = APIRouter(prefix="/compositions")
 
 
@@ -210,6 +214,46 @@ def composition_detail(
     # Count transparency: ORACC exemplar_count vs our linked count
     oracc_count = composite_meta.get("exemplar_count") if composite_meta else None
 
+    # Composition find-spots map (#198): where this text's witnesses were
+    # excavated. We count each exemplar's provenience, then intersect with the
+    # geocoded sites (GET /proveniences/coords) so the circle area reflects how
+    # many of THIS composition's tablets came from each site — the geographic
+    # companion to the transmission timeline. Witnesses whose provenience is
+    # uncertain or has no coordinates simply don't pin (reported in the caption).
+    map_pins: list = []
+    map_no_coords = 0
+    from collections import Counter
+
+    def _canon_prov(raw: str) -> str:
+        # Exemplar provenience is the display string ("Uruk (mod. Warka)"); the
+        # coords API keys on the canonical ancient_name ("Uruk"). Strip the
+        # "(mod. …)" suffix so the two line up.
+        return (raw.split("(mod.")[0] if raw else "").strip()
+
+    prov_counts: Counter = Counter(
+        _canon_prov(e.get("provenience"))
+        for e in all_exemplars
+        if e.get("provenience")
+        and _canon_prov(e.get("provenience")).lower()
+        not in ("uncertain", "unknown", "")
+    )
+    if prov_counts:
+        coords = api.get_site_coords()
+        by_name = {
+            (s.get("ancient_name") or "").lower(): s for s in coords.get("sites", [])
+        }
+        scoped_sites = []
+        placed_total = 0
+        for name, cnt in prov_counts.items():
+            site = by_name.get(name.lower())
+            if site and site.get("latitude") is not None:
+                scoped_sites.append({**site, "tablet_count": cnt})
+                placed_total += cnt
+        map_pins = build_pins(scoped_sites)
+        # Witnesses with a real site name that we still couldn't place on the map
+        # (no coordinates for that site) — surfaced honestly in the caption.
+        map_no_coords = sum(prov_counts.values()) - placed_total
+
     # Build exemplar list for the SVG timeline (all exemplars, with pipeline_status)
     # pipeline_status may be present as a field; default to None if absent
     timeline_exemplars = [
@@ -246,5 +290,9 @@ def composition_detail(
             "filter_period": filter_period,
             "filter_provenience": filter_provenience,
             "api_url": request.app.state.api.base_url,
+            "map_pins": map_pins,
+            "map_no_coords": map_no_coords,
+            "map_view_w": MAP_VIEW_W,
+            "map_view_h": MAP_VIEW_H,
         },
     )

--- a/app/routes/tablets.py
+++ b/app/routes/tablets.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import RedirectResponse
 
+from app.corpus_map import VIEW_H as MAP_VIEW_H
+from app.corpus_map import VIEW_W as MAP_VIEW_W
+from app.corpus_map import build_pins, build_single_pin
 from app.list_view import active_filters_as_dicts, build_filtered_list
 from core.config import get_settings
 
@@ -107,10 +110,11 @@ def tablet_list(
     view: str = "grid",
 ):
     api = request.app.state.api
-    # Only grid / timeline are real views in Wave 1 (#320). The map is Wave 2
-    # (gated on migration 049 + geocoding, #319) — anything unknown falls back
-    # to the grid so a stale/shared URL never lands on a blank view.
-    if view not in ("grid", "timeline"):
+    # Grid / timeline (#320) + map (#197, gated on #319's geocoded coords). The
+    # map plots each geolocated find-spot as a proportional symbol and lets a
+    # click set ?provenience= — the same linked filter as the find-spots list.
+    # Anything unknown falls back to the grid so a stale URL never lands blank.
+    if view not in ("grid", "timeline", "map"):
         view = "grid"
     # include_filter_options=true lets the API return both the page and the
     # cross-filter counts in a single round trip — half the latency of two
@@ -142,6 +146,20 @@ def tablet_list(
     )
     timeline_rows = _timeline_axis(api.get_artifacts_timeline(atlas_params))
     site_rows = api.get_artifacts_by_site({**atlas_params, "limit": 12})
+
+    # Map view (#197): geolocated find-spots as proportional symbols. The pins
+    # show the full geographic distribution of the corpus (a navigation surface,
+    # not a filtered slice) — clicking one sets ?provenience= via the SAME linked
+    # filter as the find-spots list. Built only when the map view is requested so
+    # grid/timeline loads don't pay for the coords round trip. `not_geocoded` is
+    # the count of geolocated-site rows the schematic box couldn't place (≈0 by
+    # design) — uncertain-provenance tablets are reported separately.
+    map_pins: list = []
+    map_uncertain = 0
+    if view == "map":
+        coords = api.get_site_coords()
+        map_pins = build_pins(coords.get("sites", []))
+        map_uncertain = (coords.get("uncertain") or {}).get("tablet_count", 0)
 
     lv = build_filtered_list(
         scope="tablets",
@@ -182,6 +200,10 @@ def tablet_list(
             "view": view,
             "timeline_rows": timeline_rows,
             "site_rows": site_rows,
+            "map_pins": map_pins,
+            "map_uncertain": map_uncertain,
+            "map_view_w": MAP_VIEW_W,
+            "map_view_h": MAP_VIEW_H,
         },
     )
 
@@ -247,6 +269,24 @@ def tablet_detail(request: Request, p_number: str):
     # Passed as a data attribute so sidebar.js can fetch without constructing the URL in JS.
     summarize_url = f"{request.app.state.api.base_url}/artifacts/{p_number}/summary"
 
+    # Find-spot mini-map (#199): pin this single tablet's excavation site, if it
+    # has coordinates. The find-spot is where the tablet was *excavated*
+    # (gs-expert-assyriology) — the provenience string ("Umma (mod. …)") is
+    # normalized to the canonical ancient_name and matched against the geocoded
+    # sites. No coords (e.g. uncertain provenance, or an ungeocoded site like
+    # Nineveh in production) → no map; the Provenience field still shows the name.
+    map_pin = None
+    raw_prov = (tablet.get("provenience") or "").split("(mod.")[0].strip()
+    if raw_prov and raw_prov.lower() not in ("uncertain", "unknown"):
+        coords = api.get_site_coords()
+        for s in coords.get("sites", []):
+            if (s.get("ancient_name") or "").lower() == raw_prov.lower() and s.get(
+                "latitude"
+            ) is not None:
+                # Single fixed-size pin — count is meaningless for one tablet.
+                map_pin = build_single_pin(s)
+                break
+
     from app.main import templates
 
     return templates.TemplateResponse(
@@ -263,5 +303,8 @@ def tablet_detail(request: Request, p_number: str):
             "debug_json": debug_json,
             "debug_tablets_json": debug_tablets_json,
             "web_url": settings.web_url,
+            "map_pin": map_pin,
+            "map_view_w": MAP_VIEW_W,
+            "map_view_h": MAP_VIEW_H,
         },
     )

--- a/app/static/css/components/corpus-map.css
+++ b/app/static/css/components/corpus-map.css
@@ -1,0 +1,118 @@
+/* ─── Corpus proportional-symbol map (#197–#199) ─────────────────────────────
+   Schematic Mesopotamia base + circles sized by tablet count (area ∝ count).
+   Shared by the /tablets atlas map view (#197), the composition find-spots map
+   (#198) and the tablet-detail mini-map (#199). Token-driven only — no raw hex.
+   The geographic projection + sizing happen server-side (app/corpus_map.py);
+   this stylesheet only paints. */
+
+.corpus-map {
+  margin: 0 0 var(--space-5);
+  background: var(--surface-raised);
+  border: var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-5) var(--space-4);
+}
+
+.corpus-map__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  /* The schematic land field below; the svg itself is transparent. */
+}
+
+/* ── Schematic base ──────────────────────────────────────────────────────── */
+.corpus-map__field {
+  fill: var(--color-bg-inset);
+}
+.corpus-map__river {
+  fill: none;
+  stroke: var(--color-accent-teal);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.35;
+}
+.corpus-map__region {
+  fill: var(--color-text-subtle);
+  font-size: 22px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.5;
+}
+
+/* ── Proportional symbols ────────────────────────────────────────────────── */
+.corpus-map__dot {
+  fill: var(--color-accent-25);
+  stroke: var(--color-accent);
+  stroke-width: 1.5;
+  transition: var(--transition-fast);
+}
+.corpus-map__core {
+  fill: var(--color-accent);
+  pointer-events: none;
+}
+.corpus-map__pin { cursor: pointer; }
+.corpus-map__pin:hover .corpus-map__dot,
+.corpus-map__pin:focus-visible .corpus-map__dot {
+  fill: var(--color-accent-50);
+  stroke: var(--color-accent-hover);
+}
+.corpus-map__pin:focus-visible { outline: none; }
+.corpus-map__pin:focus-visible .corpus-map__dot {
+  stroke-width: 3;
+}
+.corpus-map__pin.is-active .corpus-map__dot {
+  fill: var(--color-accent-50);
+  stroke: var(--color-accent-hover);
+  stroke-width: 3;
+}
+.corpus-map__pin--static { cursor: default; }
+
+/* ── Labels ──────────────────────────────────────────────────────────────── */
+.corpus-map__label {
+  fill: var(--color-text-muted);
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+  paint-order: stroke;
+  stroke: var(--color-bg-inset);
+  stroke-width: 3px;
+  stroke-linejoin: round;
+}
+
+/* ── Caption / coverage caveat ───────────────────────────────────────────── */
+.corpus-map__cap {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: var(--border-subtle);
+  line-height: 1.5;
+}
+.corpus-map__caveat {
+  display: block;
+  color: var(--color-text-subtle);
+  font-size: var(--text-xxs);
+}
+
+/* ── Compact / mini-map mode (#199 tablet detail) ────────────────────────── */
+.corpus-map--compact {
+  padding: var(--space-3) var(--space-3) var(--space-2);
+}
+.corpus-map--compact .corpus-map__region { font-size: 30px; }
+.corpus-map--compact .corpus-map__cap {
+  font-size: var(--text-xxs);
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
+}
+
+/* Tablet-detail find-spot mini-map wrapper (#199) */
+.tablet-findspot { margin-top: var(--space-4); max-width: 360px; }
+.tablet-findspot__label {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -24,6 +24,7 @@
 @import url('components/pagination.css');
 @import url('components/empty-states.css');
 @import url('components/corpus-atlas.css');
+@import url('components/corpus-map.css');
 @import url('components/forms.css');
 @import url('components/global-search.css');
 @import url('components/filters.css');

--- a/app/static/js/corpus-atlas.js
+++ b/app/static/js/corpus-atlas.js
@@ -15,6 +15,7 @@
   var REGIONS = [
     '[data-atlas-grid]',     // the result grid
     '[data-atlas-timeline]', // the timeline panel (selection state)
+    '[data-atlas-map]',      // the proportional-symbol map (#197)
     '[data-atlas-sites]',    // the find-spots list
     '[data-atlas-banner]',   // the linked-filter banner
     '[data-atlas-switch]',   // the view switcher (aria-pressed)
@@ -28,7 +29,7 @@
   function isAtlasLink(a) {
     if (!a) return false;
     return a.matches(
-      '[data-atlas-switch] a, [data-atlas-timeline] a, [data-atlas-sites] a, [data-atlas-banner] .clear'
+      '[data-atlas-switch] a, [data-atlas-timeline] a, [data-atlas-map] a, [data-atlas-sites] a, [data-atlas-banner] .clear'
     );
   }
 

--- a/app/templates/components/corpus_map.html
+++ b/app/templates/components/corpus_map.html
@@ -1,0 +1,87 @@
+{# ── Corpus proportional-symbol map (#197–#199) ──────────────────────────────
+   A schematic Mesopotamia base (the two rivers, sketched — no heavy basemap
+   chartjunk) with one circle per geocoded find-spot, sized so circle AREA is
+   proportional to tablet count (Tufte/Victor, from the #313 critique). Pins are
+   real <a> links when `link=True` (Victor: the map IS the filter control); a
+   static dot otherwise (composition / tablet detail). Projection + sizing are
+   done server-side in app/corpus_map.py — this macro only draws.
+
+   Params:
+     pins         list[Pin]  projected, sized find-spots (corpus_map.build_pins)
+     view_w/h     viewBox dimensions (corpus_map.VIEW_W / VIEW_H)
+     uncertain    int        count of un-pinnable uncertain-provenance tablets
+     not_geocoded int|None   count of sites/tablets with no coords (coverage)
+     link_base    str|None   when set, each pin is <a href="{link_base}{name}…">
+     active       list[str]  ancient_names currently selected (highlight ring)
+     caption      str        the honest coverage line under the map
+     compact      bool       smaller labels / no legend (mini-map mode)            #}
+
+{% macro corpus_map(pins, view_w, view_h, uncertain=0, not_geocoded=None,
+                    link_base=None, link_suffix='', active=[], caption='',
+                    compact=False, region_label='Mesopotamia') %}
+<figure class="corpus-map{{ ' corpus-map--compact' if compact }}" data-corpus-map>
+  <svg class="corpus-map__svg" viewBox="0 0 {{ view_w|int }} {{ view_h|int }}"
+       role="img" preserveAspectRatio="xMidYMid meet"
+       aria-label="Map of find-spots across Mesopotamia, each circle sized by tablet count">
+    {# ── Schematic base: the two rivers + a region wash. Decorative — aria-hidden. #}
+    <g class="corpus-map__base" aria-hidden="true">
+      <rect x="0" y="0" width="{{ view_w|int }}" height="{{ view_h|int }}"
+            class="corpus-map__field" rx="14"/>
+      {# Euphrates (NW → SE) #}
+      <path class="corpus-map__river"
+            d="M312,264 L467,406 L634,496 L657,523 L723,594 L747,615 L812,648"/>
+      {# Tigris (NW → SE), converging toward the southern marshes #}
+      <path class="corpus-map__river"
+            d="M543,252 L589,301 L595,353 L656,479 L750,578 L817,619"/>
+      <text x="{{ (view_w/2)|int }}" y="{{ (view_h - 22)|int }}"
+            class="corpus-map__region" text-anchor="middle">{{ region_label }}</text>
+    </g>
+
+    {# ── Proportional symbols: painted largest-first (build_pins order) so small
+         pins stay on top and clickable. #}
+    <g class="corpus-map__pins">
+      {% for p in pins %}
+      {% set is_active = p.ancient_name in active %}
+      {% if link_base %}
+      <a href="{{ link_base }}{{ p.ancient_name|urlencode }}{{ link_suffix }}"
+         class="corpus-map__pin{{ ' is-active' if is_active }}"
+         data-site="{{ p.ancient_name }}"
+         aria-pressed="{{ 'true' if is_active else 'false' }}">
+        <title>{{ p.ancient_name }}{% if p.modern_name %} ({{ p.modern_name }}){% endif %} — {{ '{:,}'.format(p.tablet_count) }} tablets</title>
+        <circle cx="{{ p.x }}" cy="{{ p.y }}" r="{{ p.r }}" class="corpus-map__dot"/>
+        {% if not compact %}<circle cx="{{ p.x }}" cy="{{ p.y }}" r="2" class="corpus-map__core"/>{% endif %}
+      </a>
+      {% else %}
+      <g class="corpus-map__pin corpus-map__pin--static{{ ' is-active' if is_active }}"
+         data-site="{{ p.ancient_name }}">
+        <title>{{ p.ancient_name }}{% if p.modern_name %} ({{ p.modern_name }}){% endif %}{% if p.tablet_count %} — {{ '{:,}'.format(p.tablet_count) }} tablets{% endif %}</title>
+        <circle cx="{{ p.x }}" cy="{{ p.y }}" r="{{ p.r }}" class="corpus-map__dot"/>
+        <circle cx="{{ p.x }}" cy="{{ p.y }}" r="2" class="corpus-map__core"/>
+      </g>
+      {% endif %}
+      {% endfor %}
+    </g>
+
+    {# ── Site labels: only the largest few when not compact, so the map stays
+         legible (Tufte data-ink). The biggest pins are first in `pins`. #}
+    {% if not compact %}
+    <g class="corpus-map__labels" aria-hidden="true">
+      {% for p in pins[:5] %}
+      <text x="{{ p.x }}" y="{{ (p.y - p.r - 7)|round(1) }}"
+            text-anchor="middle" class="corpus-map__label">{{ p.ancient_name }}</text>
+      {% endfor %}
+    </g>
+    {% endif %}
+  </svg>
+
+  <figcaption class="corpus-map__cap">
+    {% if caption %}{{ caption }}{% endif %}
+    {% if uncertain %}
+      <span class="corpus-map__caveat">⚠ {{ '{:,}'.format(uncertain) }} tablets of uncertain provenance are not placed.</span>
+    {% endif %}
+    {% if not_geocoded %}
+      <span class="corpus-map__caveat">{{ '{:,}'.format(not_geocoded) }} from sites without coordinates are not pinned.</span>
+    {% endif %}
+  </figcaption>
+</figure>
+{% endmacro %}

--- a/app/templates/compositions/detail.html
+++ b/app/templates/compositions/detail.html
@@ -7,6 +7,7 @@
 {% endblock %}
 
 {% from "components/_macros.html" import data_empty %}
+{% from "components/corpus_map.html" import corpus_map %}
 
 {% block content %}
 <main class="composition-detail-page">
@@ -91,6 +92,26 @@
             </div>
             {% endfor %}
         </div>
+    </section>
+    {% endif %}
+
+    {# ── Find-spots map (#198): where this composition's witnesses were dug ──
+         The geographic companion to the transmission timeline above — same
+         witnesses, placed in space instead of time. Circle area = how many of
+         this text's exemplars came from that site. Only shown when at least one
+         witness has a geocoded find-spot. #}
+    {% if map_pins %}
+    <section class="composition-map" aria-labelledby="comp-map-heading">
+        <h2 id="comp-map-heading" class="composition-timeline__title">Where its witnesses were found</h2>
+        <p class="composition-timeline__sub">
+            Each circle is a find-spot of this composition's exemplars; its area
+            is proportional to how many witnesses were recovered there.
+        </p>
+        {{ corpus_map(
+            map_pins, map_view_w, map_view_h,
+            not_geocoded=map_no_coords,
+            caption='Find-spots of this text\'s excavated witnesses.'
+        ) }}
     </section>
     {% endif %}
 

--- a/app/templates/tablets/detail.html
+++ b/app/templates/tablets/detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "components/_macros.html" import pipeline, lang_badge, ocr_badge %}
+{% from "components/corpus_map.html" import corpus_map %}
 
 {% block title %}{{ tablet.p_number }} - Glintstone{% endblock %}
 
@@ -288,6 +289,21 @@
                     {% endfor %}
                 </ul>
             </details>
+            {% endif %}
+
+            {# ── Find-spot mini-map (#199): pin this tablet's excavation site ──
+                 Only when the site is geocoded; otherwise the Provenience field
+                 above already names it. The find-spot is where the tablet was
+                 excavated. #}
+            {% if map_pin %}
+            <div class="tablet-findspot">
+                <dt class="tablet-findspot__label">Find-spot</dt>
+                {{ corpus_map(
+                    [map_pin], map_view_w, map_view_h,
+                    compact=True,
+                    caption='Excavated at ' ~ map_pin.ancient_name ~ (' (' ~ map_pin.modern_name ~ ')' if map_pin.modern_name else '') ~ '.'
+                ) }}
+            </div>
             {% endif %}
     </div>
 </header>

--- a/app/templates/tablets/list.html
+++ b/app/templates/tablets/list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "components/_macros.html" import tablet_card, stage_filter, filter_sidebar, pagination %}
+{% from "components/corpus_map.html" import corpus_map %}
 
 {% block title %}Tablets - Glintstone{% endblock %}
 
@@ -47,6 +48,10 @@
                    data-view="timeline"
                    aria-pressed="{{ 'true' if view == 'timeline' else 'false' }}">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="15" y2="12"/><line x1="3" y1="18" x2="19" y2="18"/></svg>Timeline</a>
+                <a href="/tablets?{{ fq.s }}view=map"
+                   data-view="map"
+                   aria-pressed="{{ 'true' if view == 'map' else 'false' }}">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="10" r="3"/><path d="M12 21s-7-5.5-7-11a7 7 0 0114 0c0 5.5-7 11-7 11z"/></svg>Map</a>
             </nav>
         </div>
 
@@ -101,6 +106,30 @@
                     <span>3000</span><span>2500</span><span>2000</span><span>1500</span><span>1000</span><span>500</span><span>BCE</span>
                 </div>
             </div>
+        </div>
+        {% endif %}
+
+        {# ── MAP view (#197): proportional-symbol find-spot map ────────────── #}
+        {% if view == 'map' %}
+        {# link_base carries every active filter EXCEPT provenience (the map sets
+           it) + view=map, then the macro appends &provenience=<ancient_name>.
+           Same single-select linked filter as the find-spots list. #}
+        {% set mq = namespace(s='') %}
+        {% if search %}{% set mq.s = mq.s ~ 'search=' ~ (search|urlencode) ~ '&' %}{% endif %}
+        {% for p in period %}{% set mq.s = mq.s ~ 'period=' ~ (p|urlencode) ~ '&' %}{% endfor %}
+        {% for g in genre %}{% set mq.s = mq.s ~ 'genre=' ~ (g|urlencode) ~ '&' %}{% endfor %}
+        {% for l in language %}{% set mq.s = mq.s ~ 'language=' ~ (l|urlencode) ~ '&' %}{% endfor %}
+        {% if has_ocr %}{% set mq.s = mq.s ~ 'has_ocr=1&' %}{% endif %}
+        {% if pipeline %}{% set mq.s = mq.s ~ 'pipeline=' ~ (pipeline|urlencode) ~ '&' %}{% endif %}
+        <div class="atlas-map" data-atlas-map>
+            <h2>Find-spots across Mesopotamia</h2>
+            {{ corpus_map(
+                map_pins, map_view_w, map_view_h,
+                uncertain=map_uncertain,
+                link_base='/tablets?' ~ mq.s ~ 'view=map&provenience=',
+                active=provenience,
+                caption='Each circle is one excavated find-spot; its area is proportional to the number of tablets recovered there. Click a site to filter the corpus. ' ~ (map_pins|length) ~ ' sites geolocated.'
+            ) }}
         </div>
         {% endif %}
 

--- a/tests/web/test_corpus_map.py
+++ b/tests/web/test_corpus_map.py
@@ -1,0 +1,187 @@
+"""Corpus map projection (#197–#199) — proportional-symbol find-spot maps.
+
+These pin the load-bearing geometry of app/corpus_map.py — the equirectangular
+projection, the area-proportional radius, and the honest handling of missing or
+out-of-box coordinates — independent of the database. The render layer (Jinja
+macro) trusts this math, so it must stay correct.
+"""
+
+import math
+
+from app.corpus_map import (
+    LAT_MAX,
+    LAT_MIN,
+    LON_MAX,
+    LON_MIN,
+    PAD_X,
+    PAD_Y,
+    R_MAX,
+    R_MIN,
+    SINGLE_PIN_R,
+    VIEW_H,
+    VIEW_W,
+    build_pins,
+    build_single_pin,
+    project,
+)
+
+
+def test_project_corners_map_to_padded_box():
+    # NW corner (max lat, min lon) → top-left of the drawable area.
+    x, y, ok = project(LAT_MAX, LON_MIN)
+    assert ok is True
+    assert math.isclose(x, PAD_X, abs_tol=0.01)
+    assert math.isclose(y, PAD_Y, abs_tol=0.01)
+    # SE corner (min lat, max lon) → bottom-right.
+    x, y, ok = project(LAT_MIN, LON_MAX)
+    assert math.isclose(x, VIEW_W - PAD_X, abs_tol=0.01)
+    assert math.isclose(y, VIEW_H - PAD_Y, abs_tol=0.01)
+
+
+def test_project_north_is_smaller_y():
+    # Higher latitude must render higher up (smaller y) — map north at top.
+    _, y_north, _ = project(36.0, 44.0)
+    _, y_south, _ = project(31.0, 44.0)
+    assert y_north < y_south
+
+
+def test_project_east_is_larger_x():
+    x_west, _, _ = project(33.0, 40.0)
+    x_east, _, _ = project(33.0, 47.0)
+    assert x_east > x_west
+
+
+def test_project_out_of_box_clamps_and_flags():
+    # A point far outside the box is clamped into the drawable area but flagged.
+    x, y, ok = project(10.0, 0.0)
+    assert ok is False
+    assert PAD_X <= x <= VIEW_W - PAD_X
+    assert PAD_Y <= y <= VIEW_H - PAD_Y
+
+
+def test_radius_is_area_proportional():
+    # Circle AREA ∝ count → radius ∝ √count. A 4× count is a 2× radius (above
+    # the floor). Build two pins sharing a max and check the ratio.
+    pins = build_pins(
+        [
+            {
+                "ancient_name": "Big",
+                "latitude": 32.0,
+                "longitude": 45.0,
+                "tablet_count": 400,
+            },
+            {
+                "ancient_name": "Small",
+                "latitude": 33.0,
+                "longitude": 44.0,
+                "tablet_count": 100,
+            },
+        ]
+    )
+    by = {p.ancient_name: p for p in pins}
+    # radius(count) = R_MIN + sqrt(count)/sqrt(max) * (R_MAX - R_MIN)
+    exp_big = R_MIN + 1.0 * (R_MAX - R_MIN)
+    exp_small = R_MIN + (math.sqrt(100) / math.sqrt(400)) * (R_MAX - R_MIN)
+    assert math.isclose(by["Big"].r, round(exp_big, 1), abs_tol=0.1)
+    assert math.isclose(by["Small"].r, round(exp_small, 1), abs_tol=0.1)
+
+
+def test_radius_clamped_to_min():
+    pins = build_pins(
+        [{"ancient_name": "X", "latitude": 32.0, "longitude": 45.0, "tablet_count": 1}]
+    )
+    # A single site is its own max → full radius; but a zero-count site floors.
+    pins0 = build_pins(
+        [
+            {
+                "ancient_name": "Z",
+                "latitude": 32.0,
+                "longitude": 45.0,
+                "tablet_count": 0,
+            },
+            {
+                "ancient_name": "Y",
+                "latitude": 33.0,
+                "longitude": 44.0,
+                "tablet_count": 50,
+            },
+        ]
+    )
+    z = next(p for p in pins0 if p.ancient_name == "Z")
+    assert z.r == R_MIN
+    assert pins[0].r >= R_MIN
+
+
+def test_build_pins_drops_missing_coords():
+    pins = build_pins(
+        [
+            {
+                "ancient_name": "HasCoords",
+                "latitude": 32.0,
+                "longitude": 45.0,
+                "tablet_count": 10,
+            },
+            {
+                "ancient_name": "NoLat",
+                "latitude": None,
+                "longitude": 45.0,
+                "tablet_count": 99,
+            },
+            {
+                "ancient_name": "NoLon",
+                "latitude": 32.0,
+                "longitude": None,
+                "tablet_count": 99,
+            },
+        ]
+    )
+    names = {p.ancient_name for p in pins}
+    assert names == {"HasCoords"}
+
+
+def test_build_pins_paints_largest_first():
+    pins = build_pins(
+        [
+            {
+                "ancient_name": "Small",
+                "latitude": 33.0,
+                "longitude": 44.0,
+                "tablet_count": 5,
+            },
+            {
+                "ancient_name": "Large",
+                "latitude": 32.0,
+                "longitude": 45.0,
+                "tablet_count": 500,
+            },
+        ]
+    )
+    # Largest first so small pins paint on top and stay clickable.
+    assert pins[0].ancient_name == "Large"
+
+
+def test_build_single_pin_fixed_radius():
+    pin = build_single_pin(
+        {
+            "ancient_name": "Umma",
+            "latitude": 31.65,
+            "longitude": 45.88,
+            "tablet_count": 1,
+        }
+    )
+    assert pin is not None
+    assert pin.r == SINGLE_PIN_R
+    assert pin.ancient_name == "Umma"
+
+
+def test_build_single_pin_none_without_coords():
+    assert (
+        build_single_pin(
+            {"ancient_name": "Nowhere", "latitude": None, "longitude": None}
+        )
+        is None
+    )
+
+
+def test_build_pins_empty():
+    assert build_pins([]) == []


### PR DESCRIPTION
Closes #197, #198, #199.

A **schematic Mesopotamia proportional-symbol map** (Tufte/Victor, from the #313 all-artifacts critique): circles sized so **area ∝ tablet count**, on a plain rivers-only base — no heavy basemap chartjunk — with an explicit *"N of uncertain provenance not placed"* caveat. Built on #319's `GET /proveniences/coords` (97 geolocated sites in prod). **No new map dependency** — pure server-projected SVG, so pins are real `<a>` links and the no-JS render path holds.

### One engine, three consumers
- `app/corpus_map.py` — equirectangular projection over a fixed Mesopotamia bbox + area-proportional radius (`radius ∝ √count`). Unit-tested, 11 cases.
- `components/corpus_map.html` + `corpus-map.css` — the shared schematic-SVG macro (token-driven, no raw hex).

**#197 — Atlas Map view.** Third tab in the `/tablets` view-switcher (Grid / Timeline / **Map**). Plots every geolocated find-spot; clicking a site sets `?provenience=` via the **same linked filter** as the find-spots list (`corpus-atlas.js` brushes it live + pushState), shareable as `?view=map`. The 25,559 uncertain-provenance tablets are a labeled caption, never pinned.

**#198 — Composition map.** Where a composition's witnesses were excavated — circle area = how many of *that text's* exemplars came from each site. Pairs with the transmission timeline on the detail page.

**#199 — Tablet mini-map.** A compact single-pin map of one tablet's excavation find-spot (with site label), shown only when the site is geocoded.

### Honest coverage
Ungeocoded sites and uncertain-provenance tablets simply don't pin and are surfaced in each map's caption. The find-spot is where the tablet was *excavated* (gs-expert-assyriology).

### Verification
Render-verified at desktop (1280) and mobile (390px): map renders sites proportionally (Babylon/Umma/Nippur/Uruk/Ur clustered in southern Sumer, Nineveh north — correct), click-to-filter works (Umma → 36,963 tablets + linked banner), composition map (Uruk/Susa/Nineveh scoped to witnesses), tablet mini-map. Gate green: `ruff` ✓ `mypy` ✓ `pytest` (11 new map + 16 related) ✓. Rebased on #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaVPgcKSmgDDwvBnKU4Je1