### PR TITLE
perf(deploy): skip pre-deploy pg_dump on code-only deploys; parallelise it (#219 #272)

### DIFF
--- a/ops/deploy/DEPLOY.md
+++ b/ops/deploy/DEPLOY.md
@@ -1,12 +1,12 @@
 ---
 question: "How does Glintstone get from a git commit to a running release on the VPS?"
 created: 2026-05-11
-modified: 2026-06-21
-context: "Rewritten 2026-05-12 to reflect post-VPS-cutover reality: production Postgres lives on the VPS itself (Neon decommissioned), migrations run server-side, and the branch model is `staging` → `main` with an approval gate on production."
+modified: 2026-06-23
+context: "Rewritten 2026-05-12 to reflect post-VPS-cutover reality: production Postgres lives on the VPS itself (Neon decommissioned), migrations run server-side, and the branch model is `staging` → `main` with an approval gate on production. 2026-06-23 (#219/#272): pre-deploy pg_dump now skipped on code-only deploys and parallelised (-Fd -j4) when it runs."
 status: active
 audience: [engineers, ops, claude]
 owners: [eric]
-related_issues: ["#14", "#52", "#61"]
+related_issues: ["#14", "#52", "#61", "#219", "#272"]
 related_skills: [gs-expert-deployment]
 supersedes: null
 superseded_by: null
@@ -32,7 +32,7 @@ different `/var/www/` directory and different supervisor services.
   │   ├── .env                        (runtime secrets)
   │   └── backups/
   │       ├── glintstone-YYYYMMDD-*.dump.gz   (nightly cron @ 04:15 UTC)
-  │       └── pre-deploy-prod-*.dump.gz       (every prod deploy; last 3 kept)
+  │       └── pre-deploy-prod-*.dumpdir/      (migration deploys only; -Fd parallel; last 2 kept)
   └── releases/
       ├── prod-20260512-165148-7a7b585/       ← newest, KEEP_RELEASES=5
       └── …
@@ -85,7 +85,9 @@ git push origin staging                  git push origin main
         ├── rsync release/                       ├── rsync release/
         ├── venv + pip install                   ├── venv + pip install
         ├── venv import check                    ├── venv import check
-        │                                        ├── pg_dump → pre-deploy snapshot
+        │                                        ├── pending-migration check
+        │                                        │     ├─ none  → SKIP pg_dump (code-only)
+        │                                        │     └─ found → pg_dump -Fd -j4 snapshot
         ├── migrate.py up (staging DB)           ├── migrate.py up (prod DB)
         ├── write version.txt                    ├── write version.txt
         ├── record PREV_RELEASE                  ├── record PREV_RELEASE
@@ -128,7 +130,26 @@ ops/deploy/rollback.sh prod-20260512-130149-dc1ea08     # roll back to that tag
 
 Rollback swaps **code only**. The database schema is forward. Migrations must
 be additive — never destructive — so old code can talk to a newer schema.
-For destructive recovery, restore from the matching `pre-deploy-*.dump.gz`.
+For destructive recovery, restore from the matching pre-deploy snapshot.
+
+> **Restore a pre-deploy snapshot.** Since #272 the pre-deploy snapshot is a
+> PostgreSQL **directory-format** dump (`pre-deploy-<tag>.dumpdir`, produced by
+> `pg_dump -Fd -j4`), not a single `.dump.gz` file. Restore it with `pg_restore`
+> (also parallel), **not** `psql`:
+>
+> ```bash
+> # on the VPS, as a role that owns the tables (DATABASE_URL_MIGRATIONS)
+> set -a && . /var/www/glintstone/shared/.env && set +a
+> pg_restore -j4 --clean --if-exists \
+>     -d "${DATABASE_URL_MIGRATIONS:-$DATABASE_URL}" \
+>     /var/www/glintstone/shared/backups/pre-deploy-<tag>.dumpdir
+> ```
+>
+> Drop `--clean --if-exists` to load into a fresh/empty database instead.
+> Note: a pre-deploy snapshot is only taken on deploys that **ship a migration**
+> — code-only deploys skip the dump (#219), so the relevant snapshot is the one
+> from the last migration-bearing deploy. Nightly cron backups
+> (`glintstone-YYYYMMDD-*.dump.gz`) remain the every-day recovery point.
 
 ### Laptop fallback deploy (when CI can't ship)
 
@@ -160,14 +181,30 @@ The wrapper exists so the fallback is repeatable and can't drift. It:
 
 ### About the "Deploy to Hostinger hangs" symptom
 
-The pre-deploy `pg_dump` of the ~19 GB prod DB legitimately takes **~18–20 min**
-and grows with the data. It is **not** a hang — `deploy.sh` prints a timestamped
-progress line with the dump size every ~80s. Do not cancel a deploy that is
-still printing growing dump sizes. Every long remote step (pip install, import
+Since #219/#272 most deploys **skip the pre-deploy `pg_dump` entirely**: it now
+runs only when the deploy actually ships a database migration. When it does run,
+it is a parallel `pg_dump -Fd -j4` of the ~22 GB prod DB — roughly **~5 min**,
+down from the old ~18–20 min single-stream dump. It is **not** a hang —
+`deploy.sh` prints a timestamped progress line with the dump size every ~60s. Do
+not cancel a deploy that is still printing growing dump sizes. Every long remote
+step (pip install, import
 verify, migrations) is now wrapped in its own remote `timeout`, and the SSH
 sessions use keepalive + `ConnectTimeout` + `BatchMode`, so a *genuine* stall
 fails fast with a clear error instead of pinning the job. The workflow's
 `timeout-minutes` is 40 to give the dump real headroom.
+
+> **Verify breadcrumb (#219/#272).** To confirm the skip logic is behaving:
+> - In the deploy log of a **code-only** deploy, look for
+>   `No pending migrations (N/N applied) … SKIPPING the pre-deploy pg_dump`. The
+>   `Snapshotting production DB` lines should be absent and total deploy time
+>   should be ~4–5 min.
+> - In the deploy log of a **migration-bearing** deploy, look for
+>   `K pending migration(s) … will snapshot the DB first` followed by the
+>   `Snapshotting production DB → …dumpdir (-Fd -j4)` lines, and a
+>   `pre-deploy-<tag>.dumpdir` directory in `shared/backups/`.
+> - If you ever see `Could not parse migrate.py status output — defaulting to
+>   TAKING a backup`, the detection hit an error and **fell back to dumping** (the
+>   safe default); investigate the `migrate.py status` line that printed below it.
 
 ### Hotfix prod (skip staging)
 
@@ -202,7 +239,7 @@ its URL from `/var/www/glintstone/shared/.env` at runtime; staging from
 | Import error / syntax bug in new code | venv import check (pre-swap) | Deploy aborts before symlink swap; previous release stays live |
 | Failed migration | `migrate.py up` non-zero exit | Deploy aborts pre-swap; pre-deploy snapshot is on disk |
 | New code runtime error after restart | Smoke test (curl /health, /healthz) | Auto-rollback to `PREV_RELEASE` |
-| Migration corrupted data | (not auto-detected) | Restore from `shared/backups/pre-deploy-<tag>.dump.gz` |
+| Migration corrupted data | (not auto-detected) | `pg_restore -j4` from `shared/backups/pre-deploy-<tag>.dumpdir` (see Roll back) |
 | Concurrent staging + prod deploy | GH Actions `concurrency: deploy-${{ github.ref }}` | Different refs, different VPS directories — they don't race |
 | Disk fills | `KEEP_RELEASES=5` + snapshot cap (3) | Trim is automatic; older nightly backups need a manual prune |
 | SSH key rotated | First deploy fails at `ssh-keyscan` / auth | `gh secret set HOSTINGER_SSH_KEY` |

--- a/ops/deploy/deploy.sh
+++ b/ops/deploy/deploy.sh
@@ -247,23 +247,78 @@ ssh_run "timeout 120 sh -c 'cd $RELEASE_DIR && set -a && . ./.env && set +a && \
     exit 1
 }
 
+# --- Decide whether this deploy needs a pre-deploy DB snapshot (#219 / #272) ---
+# The full pg_dump of the ~22 GB prod DB is the single biggest phase of a deploy
+# (~18 min) and it gates EVERY deploy — including code-only deploys that touch no
+# data at all. A code-only deploy can never change the database, so the previous
+# release is already a perfectly good rollback point and a fresh dump buys nothing.
+#
+# We take the dump ONLY when this release actually has a database migration to run.
+# Detection is delegated to the migration runner itself — the SAME `migrate.py`
+# that the migrations step below will execute — via its `status` command, which
+# compares the migration files shipped in THIS release against the `_migrations`
+# tracking table in the live DB and prints `Applied: N` for the count already
+# applied out of the total found. If "found" > "applied" there is at least one
+# pending migration, so the DB MAY change and we MUST back up first. If they are
+# equal, `migrate.py up` below would be a no-op and the data cannot change, so the
+# dump is safely skipped. Using the runner's own view (not a git diff) means the
+# skip decision can never disagree with what actually runs.
+#
+# FAIL-SAFE: any uncertainty defaults to TAKING the dump. If `migrate.py status`
+# errors, times out, or its output can't be parsed into two clean numbers, we set
+# migrations_pending=true and back up. A needless dump costs ~18 min; a skipped
+# backup before a real migration risks the data — so the safe default is to dump.
+migrations_pending=true   # fail-safe default: back up unless we PROVE it's unneeded
+if [ "$APP_ENV" = "production" ]; then
+    echo "[$(date -u +%H:%M:%S)] Checking for pending migrations (timeout 1m)..."
+    # `migrate.py status` prints lines like:
+    #   Found 53 migrations in /.../migrations
+    #   Applied: 53
+    # We extract the two integers and compare. Anything unexpected -> stay safe.
+    MIG_STATUS="$(ssh_run "timeout 60 sh -c 'cd $RELEASE_DIR && set -a && . ./.env && set +a && \
+        DATABASE_URL=\"\${DATABASE_URL_MIGRATIONS:-\$DATABASE_URL}\" venv/bin/python data-model/migrate.py status'" 2>/dev/null)" || MIG_STATUS=""
+    found_count="$(printf '%s\n' "$MIG_STATUS" | sed -n 's/^Found \([0-9]\{1,\}\) migrations.*/\1/p' | head -1)"
+    applied_count="$(printf '%s\n' "$MIG_STATUS" | sed -n 's/^Applied: \([0-9]\{1,\}\).*/\1/p' | head -1)"
+    if [ -n "$found_count" ] && [ -n "$applied_count" ]; then
+        if [ "$found_count" -le "$applied_count" ]; then
+            migrations_pending=false
+            echo "  No pending migrations ($applied_count/$found_count applied) — DB cannot change."
+            echo "  SKIPPING the pre-deploy pg_dump (code-only deploy; previous release is the rollback)."
+        else
+            echo "  $((found_count - applied_count)) pending migration(s) ($applied_count/$found_count applied) — will snapshot the DB first."
+        fi
+    else
+        echo "::warning::Could not parse migrate.py status output — defaulting to TAKING a backup (fail-safe)."
+        echo "::warning::status output was: ${MIG_STATUS:-<empty / command failed>}"
+    fi
+fi
+
 # --- Pre-deploy DB snapshot (production only — staging restores from prod nightly) ---
 # A failed OR timed-out pg_dump aborts the deploy: deploying without a complete
 # backup right before a migration is the risk profile we're eliminating. The
 # wait below is bounded AND fails hard — it must never fall through to migrations
 # with a partial dump on disk (see the #7 deploy-hang post-mortem, 2026-06-20).
-if [ "$APP_ENV" = "production" ]; then
-    SNAPSHOT_NAME="pre-deploy-$RELEASE_TAG.dump"
+if [ "$APP_ENV" = "production" ] && $migrations_pending; then
+    # Directory-format dump (a directory of per-table files), NOT a single file.
+    # Suffix `.dumpdir` so the rotation glob and restore command can tell the new
+    # parallel dumps apart from any legacy single-file `.dump` left on the box.
+    SNAPSHOT_NAME="pre-deploy-$RELEASE_TAG.dumpdir"
+    # Parallelism for the dump (#272). The prod box has several cores and the dump
+    # is I/O+CPU bound on a single connection with -Fc; -Fd -j N runs N worker
+    # connections in parallel and cuts wall-clock roughly N-fold. 4 is a safe
+    # default that leaves headroom for the live API/web workers also hitting PG.
+    DUMP_JOBS="${DUMP_JOBS:-4}"
 
     # --- Pre-flight: make room and verify the dump can fit ---
-    # The dump is written to the same filesystem as everything else. A 19 GB DB
-    # produces a ~6 GB -Fc dump; with the disk at ~91% used this can fail
-    # mid-write (leaving a truncated "backup"). Rotate OLD dumps BEFORE the new
-    # one runs (we previously trimmed afterward, so peak usage held 4 dumps at
-    # once), then refuse to start if free space is implausibly low.
+    # The dump is written to the same filesystem as everything else. A ~22 GB DB
+    # produces a ~6 GB compressed dump; with the disk tight this can fail mid-write
+    # (leaving a truncated "backup"). Rotate OLD dumps BEFORE the new one runs,
+    # then refuse to start if free space is implausibly low. Covers both the new
+    # `.dumpdir` directories and any legacy single-file `.dump` snapshots.
     echo "Rotating old snapshots before dump (keep newest 2)..."
-    ssh_run "cd $SHARED_DIR/backups && ls -1t pre-deploy-*.dump 2>/dev/null | tail -n +3 | xargs -r rm -f; \
-             rm -f pre-deploy-*.dump.done 2>/dev/null || true"
+    ssh_run "cd $SHARED_DIR/backups 2>/dev/null && \
+             ls -1dt pre-deploy-*.dumpdir pre-deploy-*.dump 2>/dev/null | tail -n +3 | xargs -r rm -rf; \
+             rm -f pre-deploy-*.done 2>/dev/null || true"
     AVAIL_KB=$(ssh_run "df -P $SHARED_DIR/backups | awk 'NR==2{print \$4}'")
     MIN_FREE_KB=$((10 * 1024 * 1024))   # require ~10 GB headroom for the dump
     if [ "${AVAIL_KB:-0}" -lt "$MIN_FREE_KB" ]; then
@@ -273,32 +328,41 @@ if [ "$APP_ENV" = "production" ]; then
         exit 1
     fi
 
-    # NOTE: this is the longest phase of the deploy. The prod DB is ~19 GB and
-    # the -Fc dump is ~5.7 GB, growing ~400 MB / 80s → roughly 18–20 min wall
-    # clock. The progress lines below tick every ~80s WITH a dump size so the
-    # step is visibly alive; do NOT mistake a slow-but-progressing dump for a
-    # hang and cancel it (that was the 2026-06-21 misdiagnosis). The deploy job's
-    # workflow timeout-minutes must comfortably exceed dump + rsync + migrations.
-    echo "[$(date -u +%H:%M:%S)] Snapshotting production DB → $SNAPSHOT_NAME"
-    echo "  (background dump; ~18–20 min expected for a ~19 GB DB; polling below)..."
+    # NOTE: this is the longest phase of the deploy, but it only runs on a deploy
+    # that ships a migration now (code-only deploys skipped the whole block above).
+    # With -Fd -j $DUMP_JOBS the ~22 GB DB dumps in roughly a quarter of the old
+    # ~18 min single-stream time. The progress lines below tick every ~60s WITH a
+    # dump size so the step is visibly alive; do NOT mistake a slow-but-progressing
+    # dump for a hang and cancel it (that was the 2026-06-21 misdiagnosis). The
+    # deploy job's workflow timeout-minutes must comfortably exceed dump + rsync +
+    # migrations.
+    #
+    # RESTORE (directory format): use pg_restore, NOT psql. Parallel restore too:
+    #   pg_restore -j 4 --clean --if-exists -d "$DATABASE_URL_MIGRATIONS" \
+    #       /var/www/glintstone/shared/backups/pre-deploy-<RELEASE_TAG>.dumpdir
+    # (Drop --clean/--if-exists to restore into a fresh/empty database instead.)
+    echo "[$(date -u +%H:%M:%S)] Snapshotting production DB → $SNAPSHOT_NAME (-Fd -j $DUMP_JOBS)"
+    echo "  (background parallel dump; ~5 min expected for a ~22 GB DB; polling below)..."
     # Run pg_dump in the background on the server so the SSH session doesn't need
     # to stay open for the full dump. Poll with short reconnects instead.
-    # -Fc (custom format) compresses internally — do not pipe through gzip.
+    # -Fd writes a directory of internally-compressed files; -j runs N in parallel.
+    # The directory must not pre-exist (pg_dump -Fd refuses a non-empty target), so
+    # clear any stale same-named dir from a prior aborted run first.
     ssh_run "set -a && . $SHARED_DIR/.env && set +a && \
-        mkdir -p $SHARED_DIR/backups && \
-        nohup bash -c 'pg_dump -Fc \"\${DATABASE_URL_MIGRATIONS:-\$DATABASE_URL}\" \
-            > $SHARED_DIR/backups/$SNAPSHOT_NAME \
+        mkdir -p $SHARED_DIR/backups && rm -rf $SHARED_DIR/backups/$SNAPSHOT_NAME && \
+        nohup bash -c 'pg_dump -Fd -j $DUMP_JOBS -Z 1 \
+            -f $SHARED_DIR/backups/$SNAPSHOT_NAME \
+            \"\${DATABASE_URL_MIGRATIONS:-\$DATABASE_URL}\" \
             && echo done > $SHARED_DIR/backups/$SNAPSHOT_NAME.done \
             || echo failed > $SHARED_DIR/backups/$SNAPSHOT_NAME.done' \
             > /tmp/pg_dump_deploy.log 2>&1 &"
 
     # --- Bounded wait with a HARD failure on timeout ---
-    # The DB grows over time; the previous 10-min budget was already being
-    # blown by a ~12-min dump (19 GB DB → ~6 GB -Fc). When the loop ran out it
-    # silently FELL THROUGH and ran migrations against prod with only a
-    # partial backup on disk. That is the exact failure we are eliminating:
-    # a slow dump must ABORT, not proceed. Budget = 30 min, with a timestamped
-    # progress line every minute so a future stall is diagnosable from the log.
+    # A slow dump must ABORT, not silently fall through and run migrations against
+    # prod with only a partial backup on disk (the failure we are eliminating).
+    # The parallel -Fd dump is much faster than the old single-stream -Fc, but we
+    # keep a generous 30-min budget so a transiently-loaded box doesn't false-fail;
+    # a timestamped progress line every minute keeps a future stall diagnosable.
     SNAPSHOT_MAX_MIN="${SNAPSHOT_MAX_MIN:-30}"
     snapshot_done=false
     echo "  Waiting for pg_dump (timeout ${SNAPSHOT_MAX_MIN}m)..."


### PR DESCRIPTION
## What

The full `pg_dump` of the ~22 GB prod DB (~18 min) gates **every** deploy today, including code-only deploys that change no data. It is the pacing bottleneck for the in-flight clear-out (#219, #272).

## Changes

1. **Skip the pre-deploy dump when no migration is pending.** After the release is synced and import-verified, the deploy asks the release's *own* `migrate.py status` whether any migration is pending (`Found N` vs `Applied M`, evaluated against the live `_migrations` table). If none pending, `migrate.py up` would be a no-op and the data cannot change — so the dump is skipped and the previous release is the rollback point. Common case (code-only feature deploys) drops from ~22 min to ~4–5 min.
   - **Fail-safe:** any uncertainty (status command errors / times out / output unparseable) defaults to `migrations_pending=true` → TAKE the dump. A needless dump costs time; a skipped backup before a real migration risks data.

2. **Parallelise the dump when it IS taken.** `pg_dump -Fd -j4` (directory format, parallel) replaces single-stream `-Fc` — roughly 4× faster on the multi-core VPS. Snapshot is now a `pre-deploy-<tag>.dumpdir` directory.
   - **Restore:** `pg_restore -j4 --clean --if-exists -d "$DATABASE_URL_MIGRATIONS" .../pre-deploy-<tag>.dumpdir` (documented in `deploy.sh` and `DEPLOY.md`).

All existing safety kept: disk guard, snapshot rotation, the bounded hard-fail wait, `#266` keepalives, `#271` chown/trim.

## Verification

Detection parse+decision logic tested against canned `migrate.py status` outputs:
- all-applied → **skip**; pending → **dump**; empty / garbage / partial output → **dump (fail-safe)**; zero/zero → **skip**. All pass.
- `bash -n` clean; `DEPLOY.md` header check passes.

## Note on the rollout

This PR's own deploy still uses the *old* script. The **next** code-only deploy after merge exercises the new skip path — confirm the log shows `No pending migrations … SKIPPING the pre-deploy pg_dump` and a ~4–5 min deploy. A later migration-bearing deploy should show the `-Fd -j4` snapshot. Verify breadcrumb in `DEPLOY.md`.

Closes #219, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaVPgcKSmgDDwvBnKU4Je1