### PR TITLE
feat(ingestion): eBL translations + GeoNames toponyms + DLQ open-count alerting (#165 #166 #175)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ source-data/import-tools/_progress/
 source-data/import-tools/citations/_cache/
 source-data/import-tools/citations/_progress/
 
+# Dead-letter open-count alert status files (#175) — runtime signal written by
+# ingestion.dlq_alerts; the directory is tracked (.gitkeep), the JSON snapshots
+# are per-run state and must not be committed.
+ops/snapshots/dlq-alerts/*.json
+
 # Debug output (committed-by-accident protection)
 debug-tablets.json
 *.debug.json

--- a/data-model/migrations/055_import_runs_dlq_open_after.sql
+++ b/data-model/migrations/055_import_runs_dlq_open_after.sql
@@ -1,0 +1,41 @@
+-- Migration 055: import_runs.dlq_open_after — dead-letter open-count baseline.
+--
+-- Issue #175 (dead-letter P3: open-count alerting per run, no silent growth).
+--
+-- The ingestion framework routes every record it cannot integrate into
+-- import_dead_letters (the triage queue). CLAUDE.md's non-negotiable is that
+-- failures must never grow in the dark. To detect *growth* — not just an
+-- absolute size — each run needs to know how many open dead letters this
+-- connector had at the end of its PREVIOUS run, so the post-run check can say
+-- "this run added N new open dead letters past the tolerance → ALERT".
+--
+-- This column stores the open dead-letter count for the run's connector,
+-- captured at the end of the run (ingestion.dlq_alerts.check_and_alert writes
+-- it). The next run reads the most recent non-NULL value for the same connector
+-- as its baseline. Comparing run-to-run (rather than to a fixed ceiling) means
+-- a connector with a known, triaged backlog doesn't false-alarm — only NEW
+-- bleeding pages.
+--
+-- Nullable on purpose: runs from before this migration, and runs where the
+-- alerting code failed defensively, simply carry NULL and are skipped when
+-- choosing a baseline (the check then treats the baseline as 0).
+--
+-- GRANT: import_runs already grants the app (glintstone) its read/write set;
+-- ADD COLUMN inherits the table's existing privileges, so no new GRANT is
+-- required. The column is written by the ingestion runner, which connects as
+-- the table owner.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS makes a re-run a no-op.
+
+BEGIN;
+
+ALTER TABLE import_runs
+    ADD COLUMN IF NOT EXISTS dlq_open_after INTEGER;
+
+COMMENT ON COLUMN import_runs.dlq_open_after IS
+    'Open dead-letter count (resolution_status=''open'') for this run''s '
+    'connector, captured at end of run. The next run uses the most recent '
+    'non-NULL value as its baseline to detect open-DLQ growth (issue #175). '
+    'NULL for pre-#175 runs; skipped when picking a baseline.';
+
+COMMIT;

--- a/data-model/migrations/056_provenience_geonames.sql
+++ b/data-model/migrations/056_provenience_geonames.sql
@@ -1,0 +1,106 @@
+-- Migration 056: provenience_geonames — resolve find-spots to GeoNames places.
+--
+-- Issue #166. The map program (#197-#199) places each canonical find-spot
+-- (provenience_canon) on a map using latitude/longitude. Migration 049 added
+-- those columns and ops/scripts/geocode_provenience.py fills them from the
+-- Pleiades gazetteer — but Pleiades is an ANCIENT-places gazetteer and misses
+-- many sites (the backlog notes ~106 still ungeocoded, including Nineveh under
+-- some spellings). GeoNames is a complementary, modern, far larger gazetteer
+-- (12M+ places) with excellent coverage of modern tell names and cities.
+--
+-- This table records, for each provenience that we could resolve to a GeoNames
+-- place with HIGH CONFIDENCE, the GeoNames id + coordinates + the match basis.
+-- It is the GeoNames sibling of entity_wikidata_links (#164):
+--   * keyed on the provenience identity, with the match SIGNAL stored so the
+--     audit trail explains *why* we believe the match,
+--   * accuracy over coverage — only confident matches are written; ambiguous or
+--     low-confidence candidates are dead-lettered, never guessed. A wrong place
+--     is bad scholarly data (CLAUDE.md).
+--
+-- WHY a link table (not just backfilling provenience_canon.latitude):
+--   * provenience_canon's PK is raw_provenience (a free-text spelling); many
+--     spellings share one real place. The GeoNames fact belongs to the PLACE.
+--   * Keeping the GeoNames id + match_basis + confidence separately preserves
+--     provenance: we can see which coordinates came from Pleiades vs GeoNames,
+--     re-run conservatively, and audit/repair without losing the trail.
+--   * The connector ALSO backfills provenience_canon.latitude/longitude, but
+--     ONLY where they are currently NULL (it never overwrites a Pleiades match),
+--     so the map gains coverage without the two sources fighting.
+--
+-- GRANT: NEW table owned by wittkensis; the app reads it as glintstone (map /
+-- profiles), so GRANT the CRUD set + sequence usage.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + the UNIQUE index backing the
+-- connector's ON CONFLICT make re-runs of both migration and connector no-ops.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS provenience_geonames (
+    id                BIGSERIAL PRIMARY KEY,
+
+    -- The provenience this GeoNames place is attached to. We key on the
+    -- canonical ancient_name (the site identity) rather than raw_provenience
+    -- so one confident match covers all spellings of the same site. Stored as
+    -- the exact ancient_name string present in provenience_canon.
+    ancient_name      TEXT NOT NULL,
+
+    -- The GeoNames integer id (e.g. 99070 = Mosul). Stored as text for a stable
+    -- deep-link (https://www.geonames.org/<id>) and to match other id columns.
+    geonames_id       TEXT NOT NULL,
+
+    -- The GeoNames canonical (ascii) name we matched, for human eyeballing.
+    geonames_name     TEXT,
+
+    -- Coordinates from GeoNames (decimal degrees). Copied here so the map / map
+    -- API can read them without a second lookup, and so we can audit what we
+    -- backfilled onto provenience_canon.
+    latitude          DOUBLE PRECISION NOT NULL,
+    longitude         DOUBLE PRECISION NOT NULL,
+
+    -- GeoNames feature code (e.g. PPL populated place, PPLA seat, TELL, RUIN,
+    -- ANS antiquity site). The audit trail for plausibility — an archaeological
+    -- site code is a stronger signal than a generic populated place.
+    feature_code      TEXT,
+    country_code      TEXT,
+
+    -- HOW the match was made — the trust audit trail. Values written by the
+    -- connector: 'modern-name' (provenience.modern_name == GeoNames name),
+    -- 'ancient-name' (provenience.ancient_name == a GeoNames name), 'alias'
+    -- (curated alias table). Never a fuzzy/edit-distance basis — exact folded
+    -- equality only.
+    match_basis       TEXT NOT NULL,
+
+    -- Confidence in [0,1]. Exact folded-name equality against an archaeological
+    -- feature code = 0.95; against a generic populated place = 0.85; via a
+    -- curated, human-verified alias = 1.0. Sub-1.0 because name equality (even
+    -- exact) is weaker evidence than an id-to-id map (cf. Pleiades = 1.0).
+    confidence        REAL NOT NULL DEFAULT 0.9,
+
+    -- Which import run wrote this row (framework provenance).
+    run_id            BIGINT REFERENCES import_runs(id),
+
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT provenience_geonames_confidence_range
+        CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    CONSTRAINT provenience_geonames_geonames_id_format
+        CHECK (geonames_id ~ '^[0-9]+$'),
+    CONSTRAINT provenience_geonames_lat_range
+        CHECK (latitude >= -90.0 AND latitude <= 90.0),
+    CONSTRAINT provenience_geonames_lon_range
+        CHECK (longitude >= -180.0 AND longitude <= 180.0)
+);
+
+-- One confident GeoNames match per (ancient_name, match_basis). This is the
+-- ON CONFLICT target the connector uses for idempotent re-runs.
+CREATE UNIQUE INDEX IF NOT EXISTS provenience_geonames_uq
+    ON provenience_geonames (ancient_name, match_basis);
+
+CREATE INDEX IF NOT EXISTS provenience_geonames_geonames_id_idx
+    ON provenience_geonames (geonames_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON provenience_geonames TO glintstone;
+GRANT USAGE, SELECT ON SEQUENCE provenience_geonames_id_seq TO glintstone;
+
+COMMIT;

--- a/data-model/migrations/057_ebl_translations.sql
+++ b/data-model/migrations/057_ebl_translations.sql
@@ -1,0 +1,84 @@
+-- Migration 057: ebl_translations — English translations from eBL corpus.
+--
+-- Issue #165. The electronic Babylonian Library (eBL, LMU Munich) publishes
+-- modern English translations of Babylonian/Assyrian *literary compositions*
+-- (Enūma eliš, Atraḫasīs, …) line by line. No Glintstone connector pulls them;
+-- this adds English-translation coverage for the literary corpus.
+--
+-- DATA SHAPE (audited 2026-06 against the live, UNAUTHENTICATED eBL read API):
+--   GET https://www.ebl.lmu.de/api/texts/<genre>/<cat>/<index>
+--        → the text's metadata + its chapters (stage, name).
+--   GET https://www.ebl.lmu.de/api/texts/<g>/<c>/<i>/chapters/<stage>/<name>
+--        → the chapter's reconstructed lines; each line carries a `translation`
+--          string in eBL ATF translation format:
+--             "#tr.en: When on high no word was used for heaven,\n#tr.ar: …"
+--          i.e. one or more `#tr.<lang>:` segments. We extract the `en` segment.
+--
+-- WHY A DEDICATED TABLE (not the existing `translations` table):
+--   `translations` is keyed on (p_number, line_id) — it is ARTIFACT-centric
+--   (a CDLI tablet and a specific text_line on it). eBL corpus translations are
+--   COMPOSITE-centric: they belong to the *reconstructed literary text* at a
+--   chapter line number, attested across MANY manuscripts (witnesses), not to a
+--   single CDLI p_number. Forcing them onto a p_number they don't belong to
+--   would be inventing a false artifact attribution — exactly the kind of wrong
+--   scholarly data CLAUDE.md forbids. So we store the eBL identity faithfully
+--   (text + chapter + line) and leave any confident link to `composites` /
+--   artifacts to a separate, evidence-based step.
+--
+-- GRANT: NEW table owned by wittkensis; the app reads it as glintstone
+-- (composite / literary views), so GRANT the CRUD set + sequence usage.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + the UNIQUE index backing the
+-- connector's ON CONFLICT make re-runs of both migration and connector no-ops.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS ebl_translations (
+    id              BIGSERIAL PRIMARY KEY,
+
+    -- eBL text identity (the literary composition). genre/category/index are the
+    -- three coordinates of eBL's text catalogue; text_name is denormalised for
+    -- display ("Poem of Creation (Enūma eliš)").
+    text_genre      TEXT NOT NULL,
+    text_category   INTEGER NOT NULL,
+    text_index      INTEGER NOT NULL,
+    text_name       TEXT,
+
+    -- eBL chapter identity within the text (e.g. stage 'Standard Babylonian',
+    -- name 'I'). A text has several chapters; translations live on chapter lines.
+    chapter_stage   TEXT NOT NULL,
+    chapter_name    TEXT NOT NULL,
+
+    -- The reconstructed line number within the chapter (eBL's `number`, e.g.
+    -- '1', '23a'). Stored as text because eBL line labels are not always pure
+    -- integers (primes, suffixes).
+    line_number     TEXT NOT NULL,
+
+    -- The English translation of this line (the `#tr.en:` segment, unwrapped).
+    translation_en  TEXT NOT NULL,
+
+    -- The original reconstructed transliteration of the line, kept for context /
+    -- alignment review (informational; eBL is the source of truth).
+    reconstruction  TEXT,
+
+    -- Which import run wrote this row (framework provenance).
+    run_id          BIGINT REFERENCES import_runs(id),
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One row per (text, chapter, line). This is the ON CONFLICT target the
+-- connector uses for idempotent re-runs.
+CREATE UNIQUE INDEX IF NOT EXISTS ebl_translations_uq
+    ON ebl_translations
+       (text_genre, text_category, text_index, chapter_stage, chapter_name, line_number);
+
+-- Fast lookup of all translated lines for one text (composite view).
+CREATE INDEX IF NOT EXISTS ebl_translations_text_idx
+    ON ebl_translations (text_genre, text_category, text_index);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ebl_translations TO glintstone;
+GRANT USAGE, SELECT ON SEQUENCE ebl_translations_id_seq TO glintstone;
+
+COMMIT;

--- a/ingestion/connectors/ebl_translations.py
+++ b/ingestion/connectors/ebl_translations.py
@@ -1,0 +1,437 @@
+"""eBL English-translation connector — pull literary translations from eBL.
+
+Issue #165. The electronic Babylonian Library (eBL, LMU Munich) carries modern,
+line-by-line English translations of Babylonian/Assyrian literary compositions
+(Enūma eliš, Atraḫasīs, the Catalogue of Texts and Authors, …). No connector
+pulled them; this adds English-translation coverage for the literary corpus.
+
+DATA-AVAILABILITY VERDICT (audited 2026-06 against the LIVE eBL API):
+  The eBL *read* API is publicly reachable WITHOUT authentication (the Auth0
+  requirement noted in gs-expert-integrations/sources.md is for the web UI and
+  for write/private scopes, not for reading the published corpus). Verified:
+    GET /api/texts                          → 200, the text catalogue.
+    GET /api/texts/L/1/2                     → 200, a text + its chapters.
+    GET /api/texts/L/1/2/chapters/<stage>/<name> → 200, the chapter's lines,
+        each with a `translation` string like
+          "#tr.en: When on high no word was used for heaven,\n#tr.ar: …"
+  So we walk: catalogue → each text → each chapter → each line, and extract the
+  `#tr.en:` segment. Lines with no English translation are skipped (counted).
+
+  MAPPING TO OUR ARTIFACTS — the honest answer (data-gate caveat):
+  eBL corpus translations are COMPOSITE-text translations (a reconstructed
+  literary line attested across many manuscripts), NOT per-CDLI-tablet
+  (p_number) translations. eBL manuscripts expose museum numbers, not CDLI
+  p_numbers, in the corpus payload. We therefore store the eBL identity
+  faithfully (text + chapter + line) in `ebl_translations` rather than inventing
+  a p_number attribution. Linking an eBL text to a Glintstone `composite` /
+  artifact is a separate, evidence-based step (out of scope here; a wrong link
+  is bad scholarly data).
+
+GOOD-CITIZEN POLICY (the CDLI IP-ban lesson):
+  * One HTTP request per text and one per chapter, throttled (a polite floor
+    between calls), with bounded exponential backoff + Retry-After on 429/5xx.
+  * A descriptive User-Agent with a contact.
+  * Idempotent (ON CONFLICT) so a partial run resumes cleanly.
+  * A chapter that fails after retries is dead-lettered (never aborts the run).
+
+macOS SSL note (CLAUDE.md): all fetches shell out to curl via subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+import urllib.parse
+from typing import Any, Iterable, Iterator, Optional
+
+from ingestion.base import LoadStats, RunContext, SourceConnector, SourceManifest
+
+EBL_API_BASE = "https://www.ebl.lmu.de/api"
+
+DEFAULT_USER_AGENT = (
+    "Glintstone/0.1 (Assyriology literary-translation ingest; "
+    "+https://app.glintstone.org; contact eric.wittke@gmail.com)"
+)
+
+# Polite floor between eBL requests (seconds). The corpus is a few hundred
+# chapters, so this keeps the whole run well within courteous bounds.
+DEFAULT_REQUEST_INTERVAL_S = 1.0
+
+MAX_RETRIES = 4
+BACKOFF_BASE_S = 2.0
+BACKOFF_CAP_S = 60.0
+
+
+# --- throttled fetch (curl) ------------------------------------------------
+
+_lock = threading.Lock()
+_next_allowed_at: float = 0.0
+
+
+def _throttle(interval_s: float) -> None:
+    global _next_allowed_at
+    with _lock:
+        now = time.monotonic()
+        if now < _next_allowed_at:
+            time.sleep(_next_allowed_at - now)
+            now = time.monotonic()
+        _next_allowed_at = now + interval_s
+
+
+class _FetchError(Exception):
+    """curl-level failure (network/timeout). Retryable."""
+
+
+def _curl_json(
+    url: str, *, user_agent: str, timeout_s: float = 90.0
+) -> tuple[int, bytes]:
+    """GET a URL, returning (http_status, body). Body returned even on 4xx/5xx."""
+    sep = "\x1e"
+    write_out = f"{sep}__META__{sep}%{{http_code}}"
+    cmd = [
+        "curl",
+        "-s",
+        "-S",
+        "-L",
+        "-A",
+        user_agent,
+        "-H",
+        "Accept: application/json",
+        "--max-time",
+        str(int(timeout_s)),
+        "-w",
+        write_out,
+        url,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, check=False)
+    except FileNotFoundError as e:  # pragma: no cover
+        raise _FetchError(f"curl not on PATH: {e}") from e
+    if result.returncode != 0:
+        raise _FetchError(
+            f"curl exited {result.returncode}: "
+            f"{result.stderr.decode('utf-8', errors='replace').strip()}"
+        )
+    stdout = result.stdout
+    marker = f"{sep}__META__{sep}".encode()
+    idx = stdout.rfind(marker)
+    if idx < 0:
+        raise _FetchError("curl output missing metadata trailer")
+    body = stdout[:idx]
+    status = int(stdout[idx + len(marker) :].decode("utf-8", errors="replace") or "0")
+    return status, body
+
+
+def _backoff(attempt: int) -> None:
+    time.sleep(min(BACKOFF_BASE_S * (2**attempt), BACKOFF_CAP_S))
+
+
+def _fetch_json(
+    url: str, *, user_agent: str, interval_s: float, ctx: RunContext
+) -> Optional[Any]:
+    """Fetch + parse JSON with backoff on 429/5xx/timeout. None on final failure."""
+    for attempt in range(MAX_RETRIES + 1):
+        _throttle(interval_s)
+        try:
+            status, body = _curl_json(url, user_agent=user_agent)
+        except _FetchError as e:
+            if attempt < MAX_RETRIES:
+                _backoff(attempt)
+                continue
+            ctx.warn("ebl.fetch_error", url=url, error=str(e))
+            return None
+        if status == 200:
+            try:
+                return json.loads(body)
+            except (json.JSONDecodeError, ValueError) as e:
+                ctx.warn("ebl.bad_json", url=url, error=str(e))
+                return None
+        if status == 429 or 500 <= status < 600:
+            if attempt < MAX_RETRIES:
+                ctx.info("ebl.retry", url=url, status=status, attempt=attempt + 1)
+                _backoff(attempt)
+                continue
+            ctx.warn("ebl.exhausted", url=url, status=status)
+            return None
+        # Other 4xx — retrying won't help (404 chapter, etc.).
+        ctx.warn("ebl.http_error", url=url, status=status)
+        return None
+    return None
+
+
+# --- translation parsing ---------------------------------------------------
+
+
+def extract_en(translation: Optional[str]) -> Optional[str]:
+    """Pull the English segment from an eBL translation string.
+
+    Format: "#tr.en: <english>\n#tr.ar: <arabic>\n…". There may be 0..n
+    `#tr.<lang>:` segments; a segment may wrap across following lines until the
+    next `#tr.` marker. Returns the English text, or None if absent/empty.
+    """
+    if not translation:
+        return None
+    lines = translation.split("\n")
+    en_parts: list[str] = []
+    capturing = False
+    for ln in lines:
+        stripped = ln.strip()
+        if stripped.startswith("#tr.en:"):
+            capturing = True
+            en_parts.append(stripped[len("#tr.en:") :].strip())
+        elif stripped.startswith("#tr."):
+            capturing = False  # a different-language segment begins
+        elif capturing:
+            en_parts.append(stripped)
+    text = " ".join(p for p in en_parts if p).strip()
+    return text or None
+
+
+def _line_number_str(number: Any) -> Optional[str]:
+    """eBL line `number` is sometimes a plain string ('1') and sometimes a dict
+    ({'number': 1, 'hasPrime': false, ...}). Normalise to a display string."""
+    if number is None:
+        return None
+    if isinstance(number, str):
+        return number.strip() or None
+    if isinstance(number, dict):
+        base = number.get("number")
+        if base is None:
+            return None
+        s = str(base)
+        if number.get("hasPrime"):
+            s += "'"
+        for key in ("prefixModifier", "suffixModifier"):
+            mod = number.get(key)
+            if mod:
+                s = f"{s}{mod}" if key == "suffixModifier" else f"{mod}{s}"
+        return s
+    return str(number)
+
+
+def _reconstruction_str(line: dict) -> Optional[str]:
+    """Best-effort plain reconstruction text for context (informational)."""
+    variants = line.get("variants")
+    if not variants:
+        return None
+    recon = variants[0].get("reconstruction")
+    if isinstance(recon, str):
+        return recon
+    if isinstance(recon, list):
+        # token list — join cleanValues
+        parts = [
+            str(t.get("value")) for t in recon if isinstance(t, dict) and t.get("value")
+        ]
+        return " ".join(parts) or None
+    return None
+
+
+# --- connector -------------------------------------------------------------
+
+
+class EblTranslationsConnector(SourceConnector):
+    id = "ebl-translations"
+    display_name = "eBL English Translations (literary corpus)"
+    description = (
+        "Pulls line-level English translations of Babylonian/Assyrian literary "
+        "compositions from the eBL corpus API into ebl_translations. Composite-"
+        "text level (text/chapter/line), not per-CDLI-tablet. Good API citizen."
+    )
+    kind = "corpus"
+    runs_after = ["lookup-tables"]
+    upstream_url = "https://www.ebl.lmu.de/"
+    license = "CC-BY-SA-4.0"
+    license_url = "https://creativecommons.org/licenses/by-sa/4.0/"
+    citation = "Electronic Babylonian Library (eBL), LMU Munich"
+    contact_email = "eric.wittke@gmail.com"
+
+    def __init__(
+        self,
+        *,
+        user_agent: str = DEFAULT_USER_AGENT,
+        request_interval_s: float = DEFAULT_REQUEST_INTERVAL_S,
+        limit_texts: Optional[int] = None,
+    ) -> None:
+        self.user_agent = user_agent
+        self.request_interval_s = request_interval_s
+        self.limit_texts = limit_texts
+
+    def discover(self, ctx: RunContext) -> SourceManifest:
+        # Always-run: the eBL corpus is edited continuously and the connector is
+        # idempotent, so we re-pull and upsert. No cheap upstream checksum.
+        return SourceManifest()
+
+    def _get(self, path: str, ctx: RunContext) -> Optional[Any]:
+        return _fetch_json(
+            f"{EBL_API_BASE}/{path}",
+            user_agent=self.user_agent,
+            interval_s=self.request_interval_s,
+            ctx=ctx,
+        )
+
+    def extract(self, ctx: RunContext) -> Iterator[dict]:
+        limit = ctx.config.get("limit_texts", self.limit_texts)
+
+        catalogue = self._get("texts", ctx)
+        if not isinstance(catalogue, list):
+            ctx.warn("ebl.catalogue_unavailable")
+            return
+        if limit:
+            catalogue = catalogue[: int(limit)]
+        ctx.info("ebl.texts_selected", count=len(catalogue))
+
+        texts_done = chapters_done = lines_emitted = chapters_failed = 0
+
+        for entry in catalogue:
+            genre = entry.get("genre")
+            category = entry.get("category")
+            index = entry.get("index")
+            text_name = entry.get("name")
+            if genre is None or category is None or index is None:
+                continue
+
+            text = self._get(f"texts/{genre}/{category}/{index}", ctx)
+            if not isinstance(text, dict):
+                continue
+            texts_done += 1
+            chapters = text.get("chapters") or []
+
+            for ch in chapters:
+                stage = ch.get("stage")
+                name = ch.get("name")
+                if stage is None or name is None:
+                    continue
+                stage_q = urllib.parse.quote(str(stage), safe="")
+                name_q = urllib.parse.quote(str(name), safe="")
+                chapter = self._get(
+                    f"texts/{genre}/{category}/{index}/chapters/{stage_q}/{name_q}",
+                    ctx,
+                )
+                if not isinstance(chapter, dict) or "lines" not in chapter:
+                    chapters_failed += 1
+                    ctx.dead_letter(
+                        category="no_match",
+                        subcategory="chapter_unavailable",
+                        source_key=f"{genre}/{category}/{index}/{stage}/{name}",
+                        payload={
+                            "genre": genre,
+                            "category": category,
+                            "index": index,
+                            "stage": stage,
+                            "name": name,
+                        },
+                        reason="eBL chapter fetch failed or returned no lines after retries.",
+                    )
+                    continue
+                chapters_done += 1
+
+                for line in chapter.get("lines") or []:
+                    en = extract_en(line.get("translation"))
+                    if not en:
+                        continue
+                    line_no = _line_number_str(line.get("number"))
+                    if not line_no:
+                        continue
+                    lines_emitted += 1
+                    yield {
+                        "text_genre": str(genre),
+                        "text_category": int(category),
+                        "text_index": int(index),
+                        "text_name": text_name,
+                        "chapter_stage": str(stage),
+                        "chapter_name": str(name),
+                        "line_number": line_no,
+                        "translation_en": en,
+                        "reconstruction": _reconstruction_str(line),
+                    }
+
+        ctx.info(
+            "ebl.extract_summary",
+            texts=texts_done,
+            chapters=chapters_done,
+            chapters_failed=chapters_failed,
+            lines=lines_emitted,
+        )
+
+    def load(self, ctx: RunContext, rows: Iterable[dict]) -> LoadStats:
+        stats = LoadStats()
+        for r in rows:
+            try:
+                self._load_one(ctx, r, stats)
+            except Exception as e:  # noqa: BLE001 — route, don't abort the run
+                ctx.db.rollback()
+                ctx.dead_letter(
+                    category="other",
+                    subcategory="load_failed",
+                    source_key=f"{r.get('text_genre')}/{r.get('text_category')}/"
+                    f"{r.get('text_index')}/{r.get('chapter_name')}/{r.get('line_number')}",
+                    payload={
+                        k: r.get(k)
+                        for k in (
+                            "text_genre",
+                            "text_category",
+                            "text_index",
+                            "chapter_stage",
+                            "chapter_name",
+                            "line_number",
+                        )
+                    },
+                    reason=f"load failed: {e}",
+                )
+                stats.dead_lettered += 1
+        return stats
+
+    def _load_one(self, ctx: RunContext, r: dict, stats: LoadStats) -> None:
+        row = ctx.db.execute(
+            """
+            INSERT INTO ebl_translations
+                (text_genre, text_category, text_index, text_name,
+                 chapter_stage, chapter_name, line_number,
+                 translation_en, reconstruction, run_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (text_genre, text_category, text_index,
+                         chapter_stage, chapter_name, line_number)
+            DO UPDATE SET
+                text_name      = EXCLUDED.text_name,
+                translation_en = EXCLUDED.translation_en,
+                reconstruction = EXCLUDED.reconstruction,
+                run_id         = EXCLUDED.run_id,
+                updated_at     = now()
+            RETURNING (xmax = 0) AS inserted
+            """,
+            (
+                r["text_genre"],
+                r["text_category"],
+                r["text_index"],
+                r.get("text_name"),
+                r["chapter_stage"],
+                r["chapter_name"],
+                r["line_number"],
+                r["translation_en"],
+                r.get("reconstruction"),
+                ctx.run_id,
+            ),
+        ).fetchone()
+        inserted = row["inserted"] if isinstance(row, dict) else row[0]
+        ctx.db.commit()
+        if inserted:
+            stats.inserted += 1
+        else:
+            stats.updated += 1
+
+    def verify(self, ctx: RunContext) -> None:
+        # Spot-check: no stored row may have an empty English translation (the
+        # NOT NULL column plus this guard against whitespace-only writes).
+        row = ctx.db.execute(
+            """
+            SELECT COUNT(*) AS n FROM ebl_translations
+            WHERE length(trim(translation_en)) = 0
+            """
+        ).fetchone()
+        empties = row["n"] if isinstance(row, dict) else row[0]
+        if empties:
+            raise AssertionError(
+                f"{empties} ebl_translations rows have empty English text"
+            )

--- a/ingestion/connectors/geonames_toponyms.py
+++ b/ingestion/connectors/geonames_toponyms.py
@@ -1,0 +1,530 @@
+"""GeoNames toponym resolver — resolve provenience find-spots to GeoNames places.
+
+Issue #166. Complements the Pleiades geocoder (ops/scripts/geocode_provenience.py,
+issue #196) and the Wikidata linker (#164). Pleiades is an *ancient*-places
+gazetteer and misses many sites; the backlog notes ~106 proveniences still
+ungeocoded (including Nineveh under some spellings). GeoNames is a much larger
+*modern* gazetteer (12M+ places) with strong coverage of modern tell names and
+cities, so it can lift the map's site coverage.
+
+DATA-AVAILABILITY VERDICT (audited 2026-06 before building):
+  GeoNames publishes free per-country bulk dumps at
+  https://download.geonames.org/export/dump/<CC>.zip (verified reachable: IQ
+  ~2.8 MB, SY, TR all 200). Each is a tab-separated file with columns:
+    geonameid, name, asciiname, alternatenames, latitude, longitude,
+    feature_class, feature_code, country_code, ... (19 cols, no header).
+  Mesopotamian / Near-Eastern proveniences live in a small set of modern
+  countries, so we fetch only those dumps (IQ SY TR IR JO IL LB EG KW SA),
+  cache them on disk, and do ALL matching as a local join. There is NEVER a
+  per-row network request — the same good-citizen posture the Pleiades geocoder
+  adopted after the CDLI IP-ban lesson.
+
+ACCURACY OVER COVERAGE (the load-bearing rule for #166):
+  A wrong place is bad scholarly data. We therefore match ONLY by EXACT folded
+  name equality (diacritics stripped, Assyriological transliteration normalised),
+  never by edit distance / fuzzy similarity. When a folded name resolves to:
+    * exactly ONE GeoNames place → store it (confident).
+    * MULTIPLE GeoNames places → dead-letter as ambiguous (never guess).
+    * NO GeoNames place → silently skip (counted, not an error).
+  We further bias toward archaeological/antiquity feature codes when one name
+  has several candidates within one country (a TELL / RUIN / ANS beats a generic
+  PPL), and otherwise treat >1 candidate as ambiguous.
+
+  Match priority per provenience (first hit wins):
+    1. curated alias  (human-verified, confidence 1.0)
+    2. modern_name    (provenience.modern_name, confidence 0.85 / 0.95 site)
+    3. ancient_name   (provenience.ancient_name, confidence 0.85 / 0.95 site)
+
+SIDE EFFECT (coverage lift): besides writing provenience_geonames, the connector
+backfills provenience_canon.latitude/longitude ONLY where they are currently
+NULL — it never overwrites an existing (Pleiades) coordinate, so the two
+gazetteers don't fight and the map simply gains the sites Pleiades missed.
+
+macOS SSL note (CLAUDE.md): the bulk fetch shells out to curl via subprocess.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+import subprocess
+import unicodedata
+import zipfile
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+from ingestion.base import LoadStats, RunContext, SourceConnector, SourceManifest
+
+# --- source config ---------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+CACHE_DIR = _REPO_ROOT / "source-data" / "cache" / "geonames"
+GEONAMES_BASE = "https://download.geonames.org/export/dump"
+
+# Countries that hold the overwhelming majority of cuneiform find-spots. Kept
+# deliberately small so the cache is a few MB and the local index is tight —
+# adding a country is a one-line change if a new corpus needs it.
+DEFAULT_COUNTRIES = ["IQ", "SY", "TR", "IR", "JO", "IL", "LB", "EG", "KW", "SA"]
+
+DEFAULT_USER_AGENT = (
+    "Glintstone/0.1 (Assyriology toponym resolution; "
+    "+https://app.glintstone.org; contact eric.wittke@gmail.com)"
+)
+
+# GeoNames feature codes that denote an archaeological / ancient site. A name
+# that matches one of these is a stronger signal than a generic populated place,
+# and is used to disambiguate when a name has multiple candidates in a country.
+SITE_FEATURE_CODES = {"ANS", "RUIN", "TELL", "HSTS", "PPLH"}
+
+# Confidence scoring (sub-1.0 because exact NAME equality is weaker than an
+# id-to-id map; cf. Pleiades id match = 1.0).
+CONF_ALIAS = 1.0  # human-verified curated alias
+CONF_SITE = 0.95  # exact folded name == an archaeological-site feature code
+CONF_NAME = 0.85  # exact folded name == a generic populated place
+
+MATCH_ALIAS = "alias"
+MATCH_MODERN = "modern-name"
+MATCH_ANCIENT = "ancient-name"
+
+# Curated, human-verified aliases for high-value sites whose canonical
+# provenience name matches no GeoNames name directly. Keyed by folded
+# ancient_name → folded GeoNames name KNOWN to resolve. Explicit and auditable;
+# preferred over loosening the matcher (which would risk false positives).
+CURATED_ALIASES: dict[str, str] = {
+    # Šubat-Enlil = Tell Leilan
+    "subatenlil": "tellleilan",
+    # Dur-Šarrukin = Khorsabad
+    "dursharrukin": "khorsabad",
+    # Kalhu = Nimrud
+    "kalhu": "nimrud",
+    # Akkad/Agade unknown — deliberately NOT aliased (location uncertain).
+}
+
+
+# --- name normalisation (shared doctrine with geocode_provenience.fold) -----
+
+
+def fold(s: Optional[str]) -> str:
+    """ASCII-fold + lowercase a place name for exact (non-fuzzy) matching.
+
+    Strips diacritics (Bābili → babili), normalises Assyriological
+    transliteration (š→sh, ṣ→s, ṭ→t, ḫ→h), drops non-alphanumerics. Returns ""
+    for unusable input. Identical doctrine to ops/scripts/geocode_provenience.py
+    so the two gazetteers fold names the same way.
+    """
+    if not s:
+        return ""
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = s.lower()
+    s = s.replace("š", "sh").replace("ṣ", "s").replace("ṭ", "t").replace("ḫ", "h")
+    s = s.replace("ʾ", "").replace("ʿ", "").replace("'", "")
+    s = re.sub(r"[^a-z0-9]+", "", s)
+    return s
+
+
+# Provenience placeholder names that are NOT real sites and must never be
+# geocoded — "uncertain" alone covers ~200 rows in prod. Geocoding these would
+# pin unrelated tablets to an arbitrary same-named place: bad scholarly data.
+_PLACEHOLDER_PREFIXES = ("uncertain", "unknown")
+_PLACEHOLDER_EXACT = {"uncertain", "unknown", "n/a", "none", "?", "-", ""}
+
+
+def _is_placeholder(name: Optional[str]) -> bool:
+    """True when a provenience name is a 'not a real place' placeholder."""
+    if not name:
+        return True
+    low = name.strip().lower()
+    return low in _PLACEHOLDER_EXACT or low.startswith(_PLACEHOLDER_PREFIXES)
+
+
+def _modern_candidates(modern_name: Optional[str]) -> list[str]:
+    """Folded match keys from a modern_name field (skips 'uncertain', splits commas)."""
+    if _is_placeholder(modern_name):
+        return []
+    assert modern_name is not None  # _is_placeholder guards None/empty
+    out: list[str] = []
+    for part in [modern_name, modern_name.split(",")[0]]:
+        f = fold(part)
+        if f and f not in out:
+            out.append(f)
+    return out
+
+
+# --- bulk fetch (one network call per country dump, cached) ----------------
+
+
+def _download(url: str, dest: Path, *, user_agent: str) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["curl", "-sSL", "-A", user_agent, "--max-time", "180", "-o", str(dest), url],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not dest.exists() or dest.stat().st_size == 0:
+        raise RuntimeError(f"GeoNames download failed for {url}: {result.stderr}")
+
+
+def ensure_dumps(
+    countries: list[str], *, user_agent: str, refresh: bool = False
+) -> list[Path]:
+    paths: list[Path] = []
+    for cc in countries:
+        dest = CACHE_DIR / f"{cc}.zip"
+        if refresh or not dest.exists():
+            _download(f"{GEONAMES_BASE}/{cc}.zip", dest, user_agent=user_agent)
+        paths.append(dest)
+    return paths
+
+
+# --- local index -----------------------------------------------------------
+
+# GeoNames dump column order (19 cols, tab-separated, no header).
+_COL_GEONAMEID = 0
+_COL_NAME = 1
+_COL_ASCIINAME = 2
+_COL_ALTNAMES = 3
+_COL_LAT = 4
+_COL_LON = 5
+_COL_FEATURE_CODE = 7
+_COL_COUNTRY = 8
+
+
+def build_index(dump_paths: list[Path]) -> dict[str, list[dict]]:
+    """folded name → list of candidate places.
+
+    Each candidate: {geonames_id, name, lat, lon, feature_code, country}. A name
+    that appears on several places yields several candidates — the caller decides
+    confident-vs-ambiguous. We index the ascii name, the unicode name, and each
+    alternate name, all folded, so an exact-folded lookup is O(1).
+    """
+    index: dict[str, list[dict]] = {}
+
+    def add(key: str, cand: dict) -> None:
+        if not key:
+            return
+        bucket = index.setdefault(key, [])
+        # Dedup by geonames_id within a key (one place, many spellings).
+        if not any(c["geonames_id"] == cand["geonames_id"] for c in bucket):
+            bucket.append(cand)
+
+    for path in dump_paths:
+        with zipfile.ZipFile(path) as zf:
+            inner = path.stem + ".txt"  # e.g. IQ.zip → IQ.txt
+            names = zf.namelist()
+            target = (
+                inner
+                if inner in names
+                else next(
+                    (
+                        n
+                        for n in names
+                        if n.endswith(".txt") and not n.startswith("readme")
+                    ),
+                    None,
+                )
+            )
+            if target is None:
+                continue
+            with zf.open(target) as raw:
+                text = io.TextIOWrapper(raw, encoding="utf-8")
+                reader = csv.reader(text, delimiter="\t", quoting=csv.QUOTE_NONE)
+                for row in reader:
+                    if len(row) < 9:
+                        continue
+                    try:
+                        lat = float(row[_COL_LAT])
+                        lon = float(row[_COL_LON])
+                    except (ValueError, IndexError):
+                        continue
+                    gid = row[_COL_GEONAMEID].strip()
+                    if not gid.isdigit():
+                        continue
+                    cand = {
+                        "geonames_id": gid,
+                        "name": row[_COL_ASCIINAME] or row[_COL_NAME],
+                        "lat": lat,
+                        "lon": lon,
+                        "feature_code": row[_COL_FEATURE_CODE],
+                        "country": row[_COL_COUNTRY],
+                    }
+                    add(fold(row[_COL_NAME]), cand)
+                    add(fold(row[_COL_ASCIINAME]), cand)
+                    for alt in (row[_COL_ALTNAMES] or "").split(","):
+                        add(fold(alt), cand)
+    return index
+
+
+def _resolve(candidates: list[dict]) -> tuple[Optional[dict], Optional[str], float]:
+    """Pick the confident match from a name's candidates, or report ambiguity.
+
+    Returns (chosen | None, reason_if_unresolved | None, confidence).
+    - 1 candidate → that one.
+    - >1 candidate but exactly one is an archaeological-site feature code → it
+      (sites are unambiguous targets for a find-spot).
+    - otherwise >1 candidate → ambiguous (no confident pick; never guess).
+    """
+    if not candidates:
+        return None, "no_match", 0.0
+    if len(candidates) == 1:
+        c = candidates[0]
+        conf = CONF_SITE if c["feature_code"] in SITE_FEATURE_CODES else CONF_NAME
+        return c, None, conf
+    sites = [c for c in candidates if c["feature_code"] in SITE_FEATURE_CODES]
+    if len(sites) == 1:
+        return sites[0], None, CONF_SITE
+    return None, "ambiguous", 0.0
+
+
+# --- connector -------------------------------------------------------------
+
+
+class GeonamesToponymsConnector(SourceConnector):
+    id = "geonames-toponyms"
+    display_name = "GeoNames Toponym Resolver (provenience → GeoNames place)"
+    description = (
+        "Resolves canonical provenience find-spots to GeoNames places by EXACT "
+        "folded-name equality against cached GeoNames country dumps. Stores only "
+        "confident, unambiguous matches (accuracy over coverage); backfills "
+        "provenience_canon coordinates only where NULL. Complements Pleiades."
+    )
+    kind = "derived"
+    runs_after = ["lookup-tables"]
+    upstream_url = "https://www.geonames.org/"
+    license = "CC-BY-4.0"
+    license_url = "https://creativecommons.org/licenses/by/4.0/"
+    citation = "GeoNames (https://www.geonames.org/), CC BY 4.0"
+    contact_email = "eric.wittke@gmail.com"
+
+    def __init__(
+        self,
+        *,
+        countries: Optional[list[str]] = None,
+        user_agent: str = DEFAULT_USER_AGENT,
+        refresh: bool = False,
+    ) -> None:
+        self.countries = countries or DEFAULT_COUNTRIES
+        self.user_agent = user_agent
+        self.refresh = refresh
+        self._index: dict[str, list[dict]] = {}
+
+    # --- lifecycle ---
+
+    def discover(self, ctx: RunContext) -> SourceManifest:
+        # Always-run: GeoNames dumps refresh frequently and the resolver is cheap
+        # and idempotent. (No cheap upstream checksum without downloading.)
+        return SourceManifest()
+
+    def extract(self, ctx: RunContext) -> Iterator[dict]:
+        countries = ctx.config.get("countries") or self.countries
+        refresh = bool(ctx.config.get("refresh", self.refresh))
+        ctx.info("geonames.fetch_dumps", countries=countries, refresh=refresh)
+        dumps = ensure_dumps(countries, user_agent=self.user_agent, refresh=refresh)
+        self._index = build_index(dumps)
+        ctx.info("geonames.index_built", entries=len(self._index))
+
+        rows = ctx.db.execute(
+            """
+            SELECT DISTINCT ancient_name, modern_name
+            FROM provenience_canon
+            WHERE ancient_name IS NOT NULL
+              AND length(trim(ancient_name)) > 0
+            ORDER BY ancient_name
+            """
+        ).fetchall()
+
+        matched = ambiguous = no_match = skipped_placeholder = 0
+        for r in rows:
+            ancient = r["ancient_name"] if isinstance(r, dict) else r[0]
+            modern = r["modern_name"] if isinstance(r, dict) else r[1]
+            # "uncertain" / "unknown" are not real sites — never geocode them.
+            if _is_placeholder(ancient):
+                skipped_placeholder += 1
+                continue
+            af = fold(ancient)
+
+            # Build (key, match_basis) candidates in priority order.
+            attempts: list[tuple[str, str]] = []
+            if af in CURATED_ALIASES:
+                attempts.append((CURATED_ALIASES[af], MATCH_ALIAS))
+            for k in _modern_candidates(modern):
+                attempts.append((k, MATCH_MODERN))
+            if af:
+                attempts.append((af, MATCH_ANCIENT))
+
+            chosen = None
+            chosen_basis = None
+            chosen_conf = 0.0
+            ambiguous_for_name = False
+            for key, basis in attempts:
+                cands = self._index.get(key)
+                if not cands:
+                    continue
+                pick, reason, conf = _resolve(cands)
+                if pick is not None:
+                    chosen, chosen_basis, chosen_conf = (
+                        pick,
+                        basis,
+                        (CONF_ALIAS if basis == MATCH_ALIAS else conf),
+                    )
+                    break
+                if reason == "ambiguous":
+                    ambiguous_for_name = True
+                    # keep trying lower-priority keys; only dead-letter if none resolves
+
+            if chosen is None:
+                if ambiguous_for_name:
+                    ambiguous += 1
+                    # Idempotent dead-letter: only write if this site isn't
+                    # already an open dead letter, so re-runs don't grow the DLQ
+                    # with duplicate ambiguity reports (which would trip the #175
+                    # alert every run for a stable, already-known ambiguity).
+                    if not self._already_open(ctx, ancient):
+                        ctx.dead_letter(
+                            category="no_match",
+                            subcategory="ambiguous_geonames_match",
+                            source_key=ancient,
+                            payload={"ancient_name": ancient, "modern_name": modern},
+                            reason=(
+                                "Provenience name resolves to multiple GeoNames "
+                                "places with no single archaeological-site "
+                                "disambiguator; no confident match (accuracy over "
+                                "coverage)."
+                            ),
+                        )
+                else:
+                    no_match += 1
+                continue
+
+            matched += 1
+            yield {
+                "ancient_name": ancient,
+                "geonames_id": chosen["geonames_id"],
+                "geonames_name": chosen["name"],
+                "latitude": chosen["lat"],
+                "longitude": chosen["lon"],
+                "feature_code": chosen["feature_code"] or None,
+                "country_code": chosen["country"] or None,
+                "match_basis": chosen_basis,
+                "confidence": round(chosen_conf, 2),
+            }
+
+        ctx.info(
+            "geonames.resolution_summary",
+            considered=len(rows),
+            matched=matched,
+            ambiguous=ambiguous,
+            no_match=no_match,
+            skipped_placeholder=skipped_placeholder,
+        )
+
+    @staticmethod
+    def _already_open(ctx: RunContext, ancient_name: str) -> bool:
+        """True if an open ambiguous dead letter already exists for this site."""
+        row = ctx.db.execute(
+            """
+            SELECT 1 FROM import_dead_letters
+            WHERE connector_id = %s
+              AND subcategory = 'ambiguous_geonames_match'
+              AND source_key = %s
+              AND resolution_status = 'open'
+            LIMIT 1
+            """,
+            (ctx.connector_id, ancient_name),
+        ).fetchone()
+        return row is not None
+
+    def load(self, ctx: RunContext, rows: Iterable[dict]) -> LoadStats:
+        stats = LoadStats()
+        for r in rows:
+            try:
+                self._load_one(ctx, r, stats)
+            except Exception as e:  # noqa: BLE001 — route, don't abort the run
+                ctx.db.rollback()
+                ctx.dead_letter(
+                    category="other",
+                    subcategory="load_failed",
+                    source_key=r.get("ancient_name"),
+                    payload={
+                        k: r.get(k)
+                        for k in ("ancient_name", "geonames_id", "match_basis")
+                    },
+                    reason=f"load failed: {e}",
+                )
+                stats.dead_lettered += 1
+        return stats
+
+    def _load_one(self, ctx: RunContext, r: dict, stats: LoadStats) -> None:
+        """Idempotent upsert into provenience_geonames + conservative coord backfill."""
+        row = ctx.db.execute(
+            """
+            INSERT INTO provenience_geonames
+                (ancient_name, geonames_id, geonames_name, latitude, longitude,
+                 feature_code, country_code, match_basis, confidence, run_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (ancient_name, match_basis) DO UPDATE SET
+                geonames_id   = EXCLUDED.geonames_id,
+                geonames_name = EXCLUDED.geonames_name,
+                latitude      = EXCLUDED.latitude,
+                longitude     = EXCLUDED.longitude,
+                feature_code  = EXCLUDED.feature_code,
+                country_code  = EXCLUDED.country_code,
+                confidence    = EXCLUDED.confidence,
+                run_id        = EXCLUDED.run_id,
+                updated_at    = now()
+            RETURNING (xmax = 0) AS inserted
+            """,
+            (
+                r["ancient_name"],
+                r["geonames_id"],
+                r.get("geonames_name"),
+                r["latitude"],
+                r["longitude"],
+                r.get("feature_code"),
+                r.get("country_code"),
+                r["match_basis"],
+                r["confidence"],
+                ctx.run_id,
+            ),
+        ).fetchone()
+        inserted = row["inserted"] if isinstance(row, dict) else row[0]
+
+        # Coverage lift: backfill provenience_canon coords ONLY where NULL — never
+        # overwrite an existing (e.g. Pleiades) coordinate. One ancient_name may
+        # back several raw_provenience rows; update them all.
+        ctx.db.execute(
+            """
+            UPDATE provenience_canon
+            SET latitude = %s, longitude = %s
+            WHERE ancient_name = %s
+              AND latitude IS NULL AND longitude IS NULL
+            """,
+            (r["latitude"], r["longitude"], r["ancient_name"]),
+        )
+        ctx.db.commit()
+        if inserted:
+            stats.inserted += 1
+        else:
+            stats.updated += 1
+
+    def verify(self, ctx: RunContext) -> None:
+        # Every stored match must point at an ancient_name that exists in
+        # provenience_canon (no orphans), and coordinates must be in range (the
+        # CHECK constraint already enforces range at write time; this is a
+        # cross-table integrity spot-check).
+        row = ctx.db.execute(
+            """
+            SELECT COUNT(*) AS n
+            FROM provenience_geonames g
+            WHERE NOT EXISTS (
+                SELECT 1 FROM provenience_canon p
+                WHERE p.ancient_name = g.ancient_name
+            )
+            """
+        ).fetchone()
+        orphans = row["n"] if isinstance(row, dict) else row[0]
+        if orphans:
+            raise AssertionError(
+                f"{orphans} provenience_geonames rows reference an unknown ancient_name"
+            )

--- a/ingestion/dlq_alerts.py
+++ b/ingestion/dlq_alerts.py
@@ -1,0 +1,244 @@
+"""Dead-letter open-count alerting (#175) — no silent growth.
+
+CLAUDE.md non-negotiable: "Never silently overwrite … always create a new run"
+and, more broadly, failures must never grow in the dark. The dead-letter queue
+(``import_dead_letters``) is the triage queue for every record that could not be
+integrated. If a connector starts shedding rows into it run after run and nobody
+notices, the SSOT quietly rots — exactly the silent-failure gap this closes.
+
+WHAT THIS DOES
+--------------
+After every connector run, the runner calls :func:`check_and_alert`. It:
+
+1. Reads the CURRENT open dead-letter count for the connector
+   (``resolution_status='open'``).
+2. Reads the open count recorded at the end of the connector's PREVIOUS run.
+3. If the count GREW by more than ``threshold`` rows since the last run, it
+   raises a LOUD alert on three channels (NOT email — per the no-email rule this
+   cycle):
+
+     * **stderr** — visible in CI logs and interactive terminals.
+     * **import_run_events** — a row at level ``error`` (the dashboard / status
+       view already reads this table), so the alert is durable and queryable.
+     * **a status file** — JSON written under ``GLINTSTONE_DLQ_ALERT_DIR``
+       (default ``ops/snapshots/dlq-alerts/``), one file per connector, so a
+       briefing / spine process can read "is anything bleeding?" without a DB
+       round-trip.
+
+WHY "grew since last run" and not "above an absolute ceiling"
+------------------------------------------------------------
+An absolute ceiling punishes connectors that have a known, triaged backlog of
+open dead letters (e.g. translation-line-matcher's structurally-unmatchable
+rows). What we actually care about is *new* bleeding: did THIS run add open
+dead letters beyond a small tolerance? So we compare against the previous run's
+recorded open count. The first-ever run has no baseline, so any growth past the
+threshold from zero alerts (which is correct — a brand-new connector dumping
+hundreds of rows IS worth a shout).
+
+The per-run open count is recorded on ``import_runs.dlq_open_after`` (added in
+migration 057) so the comparison is exact and survives across processes.
+
+GOOD-CITIZEN / SAFETY
+---------------------
+* This NEVER fails a run. An alert is a signal, not an error — if the alerting
+  code itself throws (e.g. the status dir is unwritable), it logs and returns;
+  the connector's own success/failure is untouched.
+* It does its own COMMIT for the ``dlq_open_after`` write and the event row, so
+  a connector that left the transaction clean stays clean.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# Default growth tolerance: a run may add up to this many open dead letters
+# before it's considered "bleeding". 0 = alert on ANY net growth. The default is
+# deliberately small but non-zero so a single transient bad row doesn't page.
+DEFAULT_THRESHOLD = int(os.environ.get("GLINTSTONE_DLQ_GROWTH_THRESHOLD", "0"))
+
+# Where the per-connector status files land. In-repo by default so a briefing /
+# spine process can read them with no DB access; override on the VPS to point at
+# a shared/persistent path if desired.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ALERT_DIR = Path(
+    os.environ.get(
+        "GLINTSTONE_DLQ_ALERT_DIR",
+        str(_REPO_ROOT / "ops" / "snapshots" / "dlq-alerts"),
+    )
+)
+
+
+@dataclass
+class DlqAlertResult:
+    """Outcome of one post-run dead-letter check (returned for tests / summary)."""
+
+    connector_id: str
+    open_now: int
+    open_before: Optional[int]
+    grew_by: Optional[int]
+    threshold: int
+    alerted: bool
+
+
+def _open_count(db: Any, connector_id: str) -> int:
+    row = db.execute(
+        """
+        SELECT COUNT(*) AS n
+        FROM import_dead_letters
+        WHERE connector_id = %s AND resolution_status = 'open'
+        """,
+        (connector_id,),
+    ).fetchone()
+    return row["n"] if isinstance(row, dict) else row[0]
+
+
+def _previous_open_after(
+    db: Any, connector_id: str, exclude_run_id: int
+) -> Optional[int]:
+    """The ``dlq_open_after`` recorded by this connector's most recent *prior* run.
+
+    Returns None when there is no prior run that recorded a value (first run, or
+    runs from before migration 057 landed) — in which case the caller treats the
+    baseline as 0.
+    """
+    row = db.execute(
+        """
+        SELECT dlq_open_after
+        FROM import_runs
+        WHERE connector_id = %s
+          AND id <> %s
+          AND dlq_open_after IS NOT NULL
+        ORDER BY started_at DESC
+        LIMIT 1
+        """,
+        (connector_id, exclude_run_id),
+    ).fetchone()
+    if row is None:
+        return None
+    val = row["dlq_open_after"] if isinstance(row, dict) else row[0]
+    return int(val) if val is not None else None
+
+
+def _record_open_after(db: Any, run_id: int, open_now: int) -> None:
+    db.execute(
+        "UPDATE import_runs SET dlq_open_after = %s WHERE id = %s",
+        (open_now, run_id),
+    )
+    db.commit()
+
+
+def _write_status_file(result: DlqAlertResult, *, alert_dir: Path) -> Optional[Path]:
+    """Write a one-file-per-connector JSON snapshot. Returns the path, or None."""
+    try:
+        alert_dir.mkdir(parents=True, exist_ok=True)
+        path = alert_dir / f"{result.connector_id}.json"
+        payload = {
+            "connector_id": result.connector_id,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+            "open_now": result.open_now,
+            "open_before": result.open_before,
+            "grew_by": result.grew_by,
+            "threshold": result.threshold,
+            "alert": result.alerted,
+            "status": "bleeding" if result.alerted else "ok",
+        }
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return path
+    except Exception as exc:  # noqa: BLE001 — alerting must never break a run
+        print(
+            f"  [warn] dlq-alert: could not write status file: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def check_and_alert(
+    ctx: Any,
+    *,
+    threshold: int = DEFAULT_THRESHOLD,
+    alert_dir: Path = DEFAULT_ALERT_DIR,
+) -> DlqAlertResult:
+    """Post-run dead-letter open-count check. Alerts loudly on growth.
+
+    Called by the runner after verify(). NEVER raises — alerting is a signal, not
+    a failure mode. Returns a :class:`DlqAlertResult` for the run summary / tests.
+
+    `ctx` is the connector's RunContext (gives us db, connector_id, run_id, and
+    the structured ``ctx.error`` event channel).
+    """
+    connector_id = ctx.connector_id
+    db = ctx.db
+    try:
+        open_now = _open_count(db, connector_id)
+        prev = _previous_open_after(db, connector_id, exclude_run_id=ctx.run_id)
+        baseline = prev if prev is not None else 0
+        grew_by = open_now - baseline
+        alerted = grew_by > threshold
+
+        # Always record the current open count so the NEXT run has a baseline.
+        _record_open_after(db, ctx.run_id, open_now)
+
+        result = DlqAlertResult(
+            connector_id=connector_id,
+            open_now=open_now,
+            open_before=prev,
+            grew_by=grew_by,
+            threshold=threshold,
+            alerted=alerted,
+        )
+
+        if alerted:
+            # Channel 1: structured, durable, dashboard-visible.
+            ctx.error(
+                "dlq.open_count_grew",
+                connector=connector_id,
+                open_now=open_now,
+                open_before=prev,
+                grew_by=grew_by,
+                threshold=threshold,
+            )
+            # Channel 2: loud stderr for CI / interactive.
+            print(
+                f"\n  !! DLQ ALERT [{connector_id}] open dead letters grew by "
+                f"{grew_by} (now {open_now}, was {baseline}); "
+                f"threshold {threshold}. Triage: "
+                f"python -m ingestion.cli dead-letters {connector_id}\n",
+                file=sys.stderr,
+            )
+        else:
+            ctx.info(
+                "dlq.open_count_ok",
+                connector=connector_id,
+                open_now=open_now,
+                open_before=prev,
+                grew_by=grew_by,
+            )
+
+        # Channel 3: status file for the spine / briefing (written every run, so
+        # a cleared queue overwrites a prior 'bleeding' snapshot with 'ok').
+        _write_status_file(result, alert_dir=alert_dir)
+        return result
+
+    except Exception as exc:  # noqa: BLE001 — never break a run over alerting
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        print(
+            f"  [warn] dlq-alert: check failed for {connector_id}: {exc}",
+            file=sys.stderr,
+        )
+        return DlqAlertResult(
+            connector_id=connector_id,
+            open_now=-1,
+            open_before=None,
+            grew_by=None,
+            threshold=threshold,
+            alerted=False,
+        )

--- a/ingestion/runner.py
+++ b/ingestion/runner.py
@@ -31,6 +31,7 @@ from ingestion.base import (
     utc_now,
 )
 from ingestion.dead_letters import DeadLetterSink
+from ingestion.dlq_alerts import check_and_alert
 
 
 def _git_sha() -> Optional[str]:
@@ -185,6 +186,10 @@ def run_connector(
                 fetched_at=manifest.fetched_at,
                 stats=ctx.stats,
             )
+            # Post-run dead-letter open-count check (#175). A no_op run still
+            # records its baseline so a later real run can detect growth, and a
+            # cleared queue refreshes the status file. Never raises.
+            check_and_alert(ctx)
             summary["status"] = "no_op"
             return summary
 
@@ -212,6 +217,12 @@ def run_connector(
             skipped=ctx.stats.skipped,
             dead_lettered=ctx.stats.dead_lettered,
         )
+        # Post-run dead-letter open-count check (#175): alert loudly (stderr +
+        # import_run_events + status file) if this run grew the open DLQ beyond
+        # threshold. Closes the silent-growth gap. Never raises.
+        alert = check_and_alert(ctx)
+        summary["dlq_open_after"] = alert.open_now
+        summary["dlq_alerted"] = alert.alerted
         summary.update(
             {
                 "status": "succeeded",

--- a/tests/test_dlq_alerts.py
+++ b/tests/test_dlq_alerts.py
@@ -1,0 +1,114 @@
+"""Unit tests for dead-letter open-count alerting (issue #175).
+
+Covers the growth-detection logic and the three alert channels (event log,
+stderr, status file) with an in-memory fake DB + ctx — no real database. The
+end-to-end wiring into the runner is exercised by test_ingestion_runner.py
+(skipped unless DATABASE_URL is set).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ingestion.dlq_alerts import check_and_alert
+
+
+class _FakeCtx:
+    """Minimal RunContext stand-in. `open_now` and `prev_open` drive the logic."""
+
+    def __init__(
+        self, *, open_now: int, prev_open: int | None, run_id: int = 99
+    ) -> None:
+        self.connector_id = "test-connector"
+        self.run_id = run_id
+        self._open_now = open_now
+        self._prev_open = prev_open
+        self.recorded_open_after: int | None = None
+        self.events: list[tuple[str, str, dict]] = []
+        self.db = self  # ctx.db.execute(...) routes back here
+
+    # --- fake db ---
+    def execute(self, sql: str, params=None):
+        s = " ".join(sql.split()).lower()
+        if "count(*)" in s and "import_dead_letters" in s:
+            return _Result({"n": self._open_now})
+        if "dlq_open_after" in s and "select" in s:
+            if self._prev_open is None:
+                return _Result(None)
+            return _Result({"dlq_open_after": self._prev_open})
+        if "update import_runs set dlq_open_after" in s:
+            self.recorded_open_after = params[0]
+            return _Result(None)
+        raise AssertionError(f"unexpected SQL: {s}")
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    # --- fake ctx event channels ---
+    def info(self, msg, **ctx):
+        self.events.append(("info", msg, ctx))
+
+    def error(self, msg, **ctx):
+        self.events.append(("error", msg, ctx))
+
+
+class _Result:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+def test_growth_past_threshold_alerts(tmp_path: Path) -> None:
+    ctx = _FakeCtx(open_now=10, prev_open=3)
+    res = check_and_alert(ctx, threshold=0, alert_dir=tmp_path)
+    assert res.alerted is True
+    assert res.open_now == 10
+    assert res.grew_by == 7
+    # error event emitted (durable, dashboard-visible channel)
+    assert any(
+        lvl == "error" and msg == "dlq.open_count_grew" for lvl, msg, _ in ctx.events
+    )
+    # baseline recorded for next run
+    assert ctx.recorded_open_after == 10
+    # status file written and marked bleeding
+    status = json.loads((tmp_path / "test-connector.json").read_text())
+    assert status["status"] == "bleeding"
+    assert status["grew_by"] == 7
+
+
+def test_no_growth_does_not_alert(tmp_path: Path) -> None:
+    ctx = _FakeCtx(open_now=3, prev_open=3)
+    res = check_and_alert(ctx, threshold=0, alert_dir=tmp_path)
+    assert res.alerted is False
+    assert not any(msg == "dlq.open_count_grew" for _, msg, _ in ctx.events)
+    status = json.loads((tmp_path / "test-connector.json").read_text())
+    assert status["status"] == "ok"
+
+
+def test_threshold_tolerates_small_growth(tmp_path: Path) -> None:
+    ctx = _FakeCtx(open_now=5, prev_open=3)
+    res = check_and_alert(ctx, threshold=2, alert_dir=tmp_path)
+    # grew by 2, threshold 2 → not past threshold
+    assert res.alerted is False
+
+
+def test_first_run_baseline_is_zero(tmp_path: Path) -> None:
+    # No prior run recorded → baseline 0 → any open dead letters alert.
+    ctx = _FakeCtx(open_now=4, prev_open=None)
+    res = check_and_alert(ctx, threshold=0, alert_dir=tmp_path)
+    assert res.alerted is True
+    assert res.open_before is None
+    assert res.grew_by == 4
+
+
+def test_first_run_clean_does_not_alert(tmp_path: Path) -> None:
+    ctx = _FakeCtx(open_now=0, prev_open=None)
+    res = check_and_alert(ctx, threshold=0, alert_dir=tmp_path)
+    assert res.alerted is False
+    assert ctx.recorded_open_after == 0

--- a/tests/test_ebl_translations_connector.py
+++ b/tests/test_ebl_translations_connector.py
@@ -1,0 +1,78 @@
+"""Unit tests for the eBL English-translation connector (issue #165).
+
+Covers the accuracy-critical pure logic — pulling the English segment out of the
+eBL multi-language translation string and normalising eBL line numbers — without
+touching the network or a database. The DB load path is exercised by the
+ingestion integration tests (skipped unless DATABASE_URL is set).
+"""
+
+from __future__ import annotations
+
+from ingestion.connectors.ebl_translations import (
+    _line_number_str,
+    _reconstruction_str,
+    extract_en,
+)
+
+
+def test_extract_en_basic_en_then_ar() -> None:
+    s = "#tr.en: When on high no word was used for heaven,\n#tr.ar: ،حينَما"
+    assert extract_en(s) == "When on high no word was used for heaven,"
+
+
+def test_extract_en_only_arabic_returns_none() -> None:
+    assert extract_en("#tr.ar: ،حين") is None
+
+
+def test_extract_en_missing_returns_none() -> None:
+    assert extract_en(None) is None
+    assert extract_en("") is None
+    assert extract_en("no markers here") is None
+
+
+def test_extract_en_wraps_continuation_lines() -> None:
+    # A #tr.en segment may continue on following lines until the next #tr. marker.
+    s = "#tr.en: first part\nsecond part\n#tr.ar: arabic"
+    assert extract_en(s) == "first part second part"
+
+
+def test_extract_en_stops_at_next_language_marker() -> None:
+    s = "#tr.en: english only\n#tr.de: deutsch\n#tr.en: more english"
+    # Both English segments are captured; the German one is excluded.
+    assert extract_en(s) == "english only more english"
+
+
+def test_line_number_str_plain_string() -> None:
+    assert _line_number_str("23") == "23"
+    assert _line_number_str("  7a ") == "7a"
+
+
+def test_line_number_str_dict_with_prime() -> None:
+    assert _line_number_str({"number": 12, "hasPrime": True}) == "12'"
+
+
+def test_line_number_str_dict_plain() -> None:
+    assert _line_number_str({"number": 1, "hasPrime": False}) == "1"
+
+
+def test_line_number_str_none() -> None:
+    assert _line_number_str(None) is None
+
+
+def test_reconstruction_str_from_string() -> None:
+    line = {"variants": [{"reconstruction": "%n enuma elis"}]}
+    assert _reconstruction_str(line) == "%n enuma elis"
+
+
+def test_reconstruction_str_from_token_list() -> None:
+    line = {
+        "variants": [
+            {"reconstruction": [{"value": "enuma"}, {"value": "elis"}, {"foo": "bar"}]}
+        ]
+    }
+    assert _reconstruction_str(line) == "enuma elis"
+
+
+def test_reconstruction_str_missing() -> None:
+    assert _reconstruction_str({}) is None
+    assert _reconstruction_str({"variants": []}) is None

--- a/tests/test_geonames_toponyms_connector.py
+++ b/tests/test_geonames_toponyms_connector.py
@@ -1,0 +1,105 @@
+"""Unit tests for the GeoNames toponym resolver (issue #166).
+
+Covers the accuracy-critical pure logic — name folding and the confident-vs-
+ambiguous resolution rule (accuracy over coverage) — without touching the
+network or a database. The DB load + coordinate-backfill path is exercised by
+the ingestion integration tests (skipped unless DATABASE_URL is set).
+"""
+
+from __future__ import annotations
+
+from ingestion.connectors.geonames_toponyms import (
+    CONF_NAME,
+    CONF_SITE,
+    _modern_candidates,
+    _resolve,
+    fold,
+)
+
+
+def _cand(gid: str, name: str, feature: str = "PPL") -> dict:
+    return {
+        "geonames_id": gid,
+        "name": name,
+        "lat": 1.0,
+        "lon": 2.0,
+        "feature_code": feature,
+        "country": "IQ",
+    }
+
+
+def test_fold_strips_diacritics_and_transliteration() -> None:
+    # NFKD decomposition strips combining marks, so precomposed š/ṣ/ṭ fold to
+    # their base letter (Aššur -> assur). This matches the shared fold() doctrine
+    # in ops/scripts/geocode_provenience.py, so both gazetteers fold names the
+    # same way and a GeoNames alternate name folds to the same key.
+    assert fold("Bābili") == "babili"
+    assert fold("Aššur") == "assur"
+    assert fold("Nineveh") == "nineveh"
+    # ḫ has no canonical decomposition, so the explicit ḫ->h replace applies.
+    assert fold("Ḫattuša") == "hattusa"
+
+
+def test_fold_drops_punctuation_and_empty() -> None:
+    assert fold("Tell  Açana") == "tellacana"
+    assert fold(None) == ""
+    assert fold("   ") == ""
+
+
+def test_modern_candidates_skips_uncertain() -> None:
+    assert _modern_candidates("uncertain") == []
+    assert _modern_candidates("Uncertain (north)") == []
+    assert _modern_candidates(None) == []
+
+
+def test_modern_candidates_splits_country_suffix() -> None:
+    # "Abydos, Egypt" should yield both the whole string and the place part.
+    keys = _modern_candidates("Abydos, Egypt")
+    assert "abydos" in keys
+
+
+def test_resolve_single_candidate_generic() -> None:
+    chosen, reason, conf = _resolve([_cand("1", "Mosul", "PPL")])
+    assert chosen is not None and chosen["geonames_id"] == "1"
+    assert reason is None
+    assert conf == CONF_NAME
+
+
+def test_resolve_single_candidate_site_gets_higher_confidence() -> None:
+    chosen, reason, conf = _resolve([_cand("2", "Nimrud", "TELL")])
+    assert chosen is not None
+    assert conf == CONF_SITE
+
+
+def test_resolve_multiple_generic_is_ambiguous() -> None:
+    # Two unrelated populated places with the same folded name => never guess.
+    chosen, reason, conf = _resolve(
+        [_cand("1", "Kish", "PPL"), _cand("2", "Kish", "PPL")]
+    )
+    assert chosen is None
+    assert reason == "ambiguous"
+
+
+def test_resolve_multiple_with_one_site_disambiguates() -> None:
+    # A single archaeological-site code among the candidates is the confident pick.
+    cands = [
+        _cand("1", "Foo", "PPL"),
+        _cand("2", "Foo", "TELL"),
+        _cand("3", "Foo", "PPL"),
+    ]
+    chosen, reason, conf = _resolve(cands)
+    assert chosen is not None and chosen["geonames_id"] == "2"
+    assert conf == CONF_SITE
+
+
+def test_resolve_multiple_sites_stays_ambiguous() -> None:
+    cands = [_cand("1", "Foo", "TELL"), _cand("2", "Foo", "RUIN")]
+    chosen, reason, _ = _resolve(cands)
+    assert chosen is None
+    assert reason == "ambiguous"
+
+
+def test_resolve_empty_is_no_match() -> None:
+    chosen, reason, _ = _resolve([])
+    assert chosen is None
+    assert reason == "no_match"


### PR DESCRIPTION
Imports + DLQ batch.

- **#165 eBL translations** connector + migration 057 (ebl_translations table)
- **#166 GeoNames toponyms** connector + migration 056 (provenience_canon geonames coords backfill — NULL-only, never overwrites Pleiades; ambiguous matches dead-lettered)
- **#175 DLQ open-count alerting** — `dlq_alerts.check_and_alert` post-run hook in runner.py + migration 055 (import_runs dlq_open_after) + status file under ops/snapshots/dlq-alerts/

Migrations 055/056/057 → deploy will take a pre-deploy pg_dump (-Fd -j4 parallel).
Gate: 413 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)