### PR TITLE
perf: parallelize tablet-list + warm query-embed & interpret caches (#115 #253 #411)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -31,9 +31,36 @@ from core.version import release_tag, version_payload
 logger = logging.getLogger(__name__)
 
 
+def _warm_query_cache() -> None:
+    """Pre-warm the popular query-embed cache (#253) off the request path.
+
+    Runs in a background thread from startup so a cold ~1.4-1.9s Voyage embed is
+    paid once at boot instead of on the first user search after a deploy. Fully
+    best-effort: a missing key or a Voyage hiccup just leaves the queries to
+    embed lazily on first use, exactly as before — it must never delay startup or
+    crash the process.
+    """
+    try:
+        from api.services.agent_service import _get_voyage
+        from core.agent.search_engine import warm_query_cache
+
+        n = warm_query_cache(_get_voyage())
+        logger.info("query-embed warm-cache: %d queries pinned", n)
+    except Exception as exc:  # never let warming break startup
+        logger.warning("query-embed warm-cache skipped: %r", exc)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_pool()
+    # Warm the popular query-embed cache in a daemon thread so the first hero
+    # search after a deploy isn't cold (#253). Backgrounded so it never delays
+    # the server accepting connections or the /health smoke test.
+    import threading
+
+    threading.Thread(
+        target=_warm_query_cache, name="warm-query-cache", daemon=True
+    ).start()
     yield
     close_pool()
 

--- a/api/routes/agent.py
+++ b/api/routes/agent.py
@@ -346,3 +346,61 @@ def batch_summarize(
         queued=len(candidates),
         message=f"Queued {len(candidates)} artifact(s) for summarization.",
     )
+
+
+class BatchInterpretParams(BaseModel):
+    limit: int = 100
+    surfaceless_only: bool = True
+    skip_cached: bool = True
+
+
+class BatchInterpretResponse(BaseModel):
+    queued: int
+    message: str
+
+
+def _run_interpret_batch(conn, params: BatchInterpretParams) -> None:
+    """Fire-and-forget worker — warms the token-interpretation cache (#411)."""
+    import argparse  # noqa: PLC0415
+    import logging  # noqa: PLC0415
+
+    from core.agent.batch import cmd_interpret  # noqa: PLC0415
+
+    logger = logging.getLogger(__name__)
+    logger.info("batch/interpret: starting (limit=%d)", params.limit)
+    ns = argparse.Namespace(
+        limit=params.limit,
+        surfaceless_only=params.surfaceless_only,
+        skip_cached=params.skip_cached,
+        dry_run=False,
+    )
+    cmd_interpret(ns)
+
+
+@corrections_router.post(
+    "/batch/interpret",
+    response_model=BatchInterpretResponse,
+    summary="Warm the token-interpretation cache in the background (internal, #411)",
+)
+def batch_interpret(
+    body: BatchInterpretParams,
+    background_tasks: BackgroundTasks,
+    conn=Depends(get_db),
+) -> BatchInterpretResponse:
+    """Enqueues a background pass that pre-runs interpret_token for lemmatized
+    tokens so the first user interpret is a warm cache hit (~ms) instead of the
+    cold 30-45s chain (#411). Idempotent: skips tokens with a fresh cached
+    interpretation by default; defaults to the surface-less #407 risk surface."""
+    from core.agent.batch import _fetch_interpret_candidates  # noqa: PLC0415
+
+    candidates = _fetch_interpret_candidates(
+        conn,
+        limit=body.limit,
+        surfaceless_only=body.surfaceless_only,
+        skip_cached=body.skip_cached,
+    )
+    background_tasks.add_task(_run_interpret_batch, conn, body)
+    return BatchInterpretResponse(
+        queued=len(candidates),
+        message=f"Queued {len(candidates)} token(s) for interpretation warming.",
+    )

--- a/app/routes/tablets.py
+++ b/app/routes/tablets.py
@@ -1,5 +1,6 @@
 """Tablet routes — list and detail."""
 
+import concurrent.futures
 import json
 import logging
 import math
@@ -135,8 +136,6 @@ def tablet_list(
     if has_ocr:
         params["has_ocr"] = "true"
 
-    artifact_page = api.list_artifacts(params)
-
     # Corpus-Atlas aggregates (#320): per-period counts (timeline) + ranked
     # find-spots (geography lens), both over the SAME active filter as the grid.
     # Fetched on every load so the view-switcher flips instantly client-side and
@@ -144,8 +143,28 @@ def tablet_list(
     atlas_params = _atlas_filter_params(
         search, pipeline, period, provenience, genre, language, has_ocr
     )
-    timeline_rows = _timeline_axis(api.get_artifacts_timeline(atlas_params))
-    site_rows = api.get_artifacts_by_site({**atlas_params, "limit": 12})
+
+    # #115 — these API round trips are independent of one another, so fire them
+    # concurrently instead of sequentially. The page artifact list, the timeline
+    # aggregate, the by-site aggregate (and, on the map view, the site coords) all
+    # hit the API over HTTP; running them in parallel collapses the page-load
+    # latency from the SUM of the calls to the MAX. httpx.Client is thread-safe
+    # for concurrent requests, and every api.* method here already degrades to an
+    # empty/well-formed result on failure, so a slow or failing branch can never
+    # 500 the page — same contract as before, just overlapped. Mirrors the
+    # ThreadPoolExecutor pattern in core/agent/search_engine.py.
+    want_coords = view == "map"
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        page_future = executor.submit(api.list_artifacts, params)
+        timeline_future = executor.submit(api.get_artifacts_timeline, atlas_params)
+        site_future = executor.submit(
+            api.get_artifacts_by_site, {**atlas_params, "limit": 12}
+        )
+        coords_future = executor.submit(api.get_site_coords) if want_coords else None
+
+        artifact_page = page_future.result()
+        timeline_rows = _timeline_axis(timeline_future.result())
+        site_rows = site_future.result()
 
     # Map view (#197): geolocated find-spots as proportional symbols. The pins
     # show the full geographic distribution of the corpus (a navigation surface,
@@ -156,8 +175,8 @@ def tablet_list(
     # design) — uncertain-provenance tablets are reported separately.
     map_pins: list = []
     map_uncertain = 0
-    if view == "map":
-        coords = api.get_site_coords()
+    if coords_future is not None:
+        coords = coords_future.result()
         map_pins = build_pins(coords.get("sites", []))
         map_uncertain = (coords.get("uncertain") or {}).get("tablet_count", 0)
 

--- a/core/agent/batch.py
+++ b/core/agent/batch.py
@@ -1,15 +1,30 @@
-"""Batch summarization CLI.
+"""Batch agent-cache CLI.
 
 Usage:
     python -m core.agent.batch summarize [OPTIONS]
+    python -m core.agent.batch interpret [OPTIONS]
 
-Options:
+`summarize` seeds the artifact-summary cache. `interpret` (#411) seeds the
+token-interpretation cache so the first `interpret_token` on a token is a warm
+``agent_outputs`` hit (~ms) instead of the cold 30-45s Claude chain-assembly —
+the UX risk on the newly-unlocked 264k surfaceless lines (#407).
+
+summarize options:
     --limit N           Max artifacts to process (default: 100)
     --focus FOCUS       Summary focus (default: general)
     --lang LANG         Filter by language substring, e.g. "Sumerian"
     --period PERIOD     Filter by period substring, e.g. "Old Babylonian"
     --skip-cached       Skip artifacts that already have a fresh cached summary
                         (default: True — pass --no-skip-cached to force re-run)
+    --dry-run           Print what would run without calling the API
+
+interpret options:
+    --limit N           Max tokens to process (default: 100)
+    --surfaceless-only  Only warm tokens on surface-less lines (the #407 risk
+                        surface) — default True; pass --no-surfaceless-only to
+                        warm any lemmatized token.
+    --skip-cached       Skip tokens that already have a fresh cached
+                        interpretation (default: True)
     --dry-run           Print what would run without calling the API
 """
 
@@ -29,6 +44,7 @@ from core.database import connect_one_shot
 logger = logging.getLogger(__name__)
 
 _PROMPT_VERSION = "synthesis.v2"
+_INTERPRET_PROMPT_VERSION = "interpret-token.v1"
 _DEFAULT_LIMIT = 100
 _DEFAULT_FOCUS = "general"
 
@@ -158,6 +174,145 @@ def cmd_summarize(args: argparse.Namespace) -> int:
     return 0 if errors == 0 else 1
 
 
+def _fetch_interpret_candidates(
+    conn: psycopg.Connection[DictRow],
+    *,
+    limit: int,
+    surfaceless_only: bool,
+    skip_cached: bool,
+) -> list[tuple[str, int]]:
+    """Return (p_number, token_id) pairs eligible for interpret-cache warming.
+
+    Only LEMMATIZED tokens are warmed — those produce a real grounded chain (an
+    un-lemmatized token returns a fast hypotheses response, not the expensive
+    chain). When ``surfaceless_only`` is set we restrict to tokens on surface-less
+    lines (``text_lines.surface_id IS NULL``) — the newly-unlocked #407 surface
+    that the issue (#411) flags as the cold-latency risk. ``skip_cached`` excludes
+    tokens that already have a fresh, non-superseded cached interpretation, so the
+    pass is idempotent and re-runnable.
+    """
+    conditions = ["lz.token_id IS NOT NULL"]
+    params: list = []
+
+    if surfaceless_only:
+        conditions.append("tl.surface_id IS NULL")
+
+    if skip_cached:
+        conditions.append(
+            """
+            NOT EXISTS (
+                SELECT 1 FROM agent_outputs ao
+                WHERE ao.output_type = 'token_interpretation'
+                  AND ao.target_type = 'token'
+                  AND ao.target_id = t.id::text
+                  AND ao.focus IS NULL
+                  AND ao.prompt_version = %s
+                  AND ao.superseded_at IS NULL
+                  AND ao.generated_at > now() - INTERVAL '30 days'
+            )
+            """
+        )
+        params.append(_INTERPRET_PROMPT_VERSION)
+
+    where = " AND ".join(conditions)
+    params.append(limit)
+
+    with conn.cursor() as cur:
+        # DISTINCT on token id — a token can carry multiple lemmatizations, but we
+        # only need to warm each token once. Ordered by p_number, token id for a
+        # stable, resumable scan.
+        cur.execute(
+            f"""
+            SELECT DISTINCT tl.p_number AS p_number, t.id AS token_id
+            FROM tokens t
+            JOIN text_lines tl ON t.line_id = tl.id
+            JOIN lemmatizations lz ON lz.token_id = t.id
+            WHERE {where}
+            ORDER BY tl.p_number, t.id
+            LIMIT %s
+            """,
+            params,
+        )
+        return [(row["p_number"], row["token_id"]) for row in cur.fetchall()]
+
+
+def cmd_interpret(args: argparse.Namespace) -> int:
+    """Warm the token-interpretation cache (#411).
+
+    Pre-runs ``do_interpret_token`` for lemmatized tokens so the first user
+    interpret is a warm cache hit (~ms) rather than the cold 30-45s chain. Same
+    lazy-persist path as a live request, so it writes the SAME ``agent_outputs``
+    rows a user would have triggered — no parallel cache, no schema change."""
+    from api.services import agent_service  # noqa: PLC0415
+
+    settings = get_settings()
+    conn = connect_one_shot()
+
+    candidates = _fetch_interpret_candidates(
+        conn,
+        limit=args.limit,
+        surfaceless_only=args.surfaceless_only,
+        skip_cached=args.skip_cached,
+    )
+
+    if not candidates:
+        print("No candidates found — nothing to do.")
+        return 0
+
+    scope = "surface-less" if args.surfaceless_only else "all-lemmatized"
+    print(f"Batch interpret: {len(candidates)} tokens, scope={scope}")
+    if args.dry_run:
+        for p, tid in candidates:
+            print(f"  [dry-run] {p} token={tid}")
+        return 0
+
+    anthropic_key = (
+        settings.anthropic_api_key if hasattr(settings, "anthropic_api_key") else None
+    )
+    if not anthropic_key:
+        print("ERROR: ANTHROPIC_API_KEY not set.", file=sys.stderr)
+        return 1
+
+    ok = skipped = errors = 0
+
+    for i, (p_number, token_id) in enumerate(candidates, 1):
+        print(
+            f"  [{i}/{len(candidates)}] {p_number} token={token_id} … ",
+            end="",
+            flush=True,
+        )
+        try:
+            resp = agent_service.do_interpret_token(
+                conn,
+                p_number=p_number,
+                token_id=token_id,
+                interaction_id_int=None,
+                interaction_id_str=f"batch-{p_number}-{token_id}",
+            )
+            # do_interpret_token commits the lazy-persist insert on its own; a
+            # populated chain means the cache row is now warm.
+            if resp.data and (resp.data.steps or resp.data.hypotheses):
+                print("ok")
+                ok += 1
+            else:
+                print("skipped (no chain)")
+                skipped += 1
+        except Exception as exc:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            print(f"error: {exc}")
+            errors += 1
+
+        if i < len(candidates):
+            time.sleep(0.25)
+
+    print(f"\nDone: {ok} ok, {skipped} skipped, {errors} errors")
+    conn.close()
+    return 0 if errors == 0 else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m core.agent.batch",
@@ -177,12 +332,29 @@ def main(argv: list[str] | None = None) -> int:
     )
     summarize_p.add_argument("--dry-run", action="store_true")
 
+    interpret_p = subparsers.add_parser(
+        "interpret", help="Warm the token-interpretation cache (#411)"
+    )
+    interpret_p.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+    interpret_p.add_argument(
+        "--surfaceless-only",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Only warm tokens on surface-less lines (the #407 risk surface)",
+    )
+    interpret_p.add_argument(
+        "--skip-cached", action=argparse.BooleanOptionalAction, default=True
+    )
+    interpret_p.add_argument("--dry-run", action="store_true")
+
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
 
     if args.command == "summarize":
         return cmd_summarize(args)
+    if args.command == "interpret":
+        return cmd_interpret(args)
 
     parser.print_help()
     return 1

--- a/core/agent/popular_queries.py
+++ b/core/agent/popular_queries.py
@@ -1,0 +1,56 @@
+"""Popular / common hero-search queries to pre-warm the Voyage query-embed cache.
+
+#253 — a COLD Voyage query embedding costs ~1.4-1.9s and is the dominant cost on
+the hero search path on a cache miss (warm is ~240ms). The in-process cache in
+``core/agent/search_engine.py`` is cleared on every process restart (deploy /
+reboot), so the *first* search after a deploy — and any popular query that falls
+out of the 5-minute TTL — pays the full cold cost.
+
+This list is the warm-cache seed: the queries we expect scholars to hit first.
+``warm_query_cache()`` (in search_engine) embeds them once at API startup and
+PINS them so they never expire, keeping scenario-1 (the cold hero path) under the
+800 ms budget for the common case.
+
+Keep this list SMALL and HIGH-SIGNAL. Each entry is one Voyage embed call at
+startup (batched), and a pinned entry never leaves memory. Add a query here when
+search analytics show it is both common and semantically routed (not an exact
+P-number / Q-number match, which short-circuits before embedding). Curated
+2026-06 from the demo/onboarding search terms and the most common domain themes.
+"""
+
+# Common semantic hero-search queries (NOT exact P/Q-number lookups — those
+# short-circuit before any embedding). Lowercased; the cache key is hashed from
+# the raw query, so these should match the canonical form the UI sends.
+POPULAR_QUERIES: list[str] = [
+    # Genres / text types
+    "administrative records",
+    "royal inscriptions",
+    "literary texts",
+    "lexical lists",
+    "legal documents",
+    "letters",
+    "school texts",
+    "omens",
+    "hymns and prayers",
+    "mathematical texts",
+    # Themes / topics
+    "barley rations",
+    "temple offerings",
+    "land sale",
+    "loan of silver",
+    "king of ur",
+    "flood story",
+    "creation myth",
+    "beer and bread",
+    "seal impressions",
+    "year names",
+    # Deities / proper-noun themes commonly searched semantically
+    "the goddess inanna",
+    "the god enlil",
+    "gilgamesh",
+]
+
+
+def popular_queries() -> list[str]:
+    """Return the warm-cache seed list (copy, so callers can't mutate the seed)."""
+    return list(POPULAR_QUERIES)

--- a/core/agent/search_engine.py
+++ b/core/agent/search_engine.py
@@ -13,7 +13,9 @@ acquires its own pool connection so that the ~200-1000 ms Voyage network call
 overlaps with the lexical DB query instead of sitting after it.
 
 Cursor format: base64-encoded JSON of {q_hash, score_floor, last_id, types}.
-Query embeddings cached in-process by q_hash for 5 minutes (cursor TTL).
+Query embeddings cached in-process by q_hash for 5 minutes (cursor TTL). Popular
+queries are pre-warmed and PINNED at startup (never expire) so the cold Voyage
+embed isn't paid on the first hero search after a deploy (#253).
 """
 
 from __future__ import annotations
@@ -86,17 +88,22 @@ class SearchResults:
 
 # ── In-process query embedding cache ─────────────────────────────────────────
 
-
-_QUERY_VEC_CACHE: dict[str, tuple[float, list[float]]] = {}
+# Cache entries are (stored_at, vector, pinned). A PINNED entry (#253) is a
+# pre-warmed popular query: it never expires, so the cold ~1.4-1.9s Voyage embed
+# is paid once at startup instead of on the first user search after every deploy.
+# Unpinned entries keep the original 5-minute (cursor-TTL) behaviour.
+_QUERY_VEC_CACHE: dict[str, tuple[float, list[float], bool]] = {}
 
 
 def _cached_query_vector(voyage: VoyageClient, q: str) -> list[float]:
     h = hashlib.sha256(q.encode()).hexdigest()
     now = time.time()
     cached = _QUERY_VEC_CACHE.get(h)
-    if cached and (now - cached[0]) < _CURSOR_TTL_SECONDS:
-        logger.debug("voyage cache hit q_hash=%s", h[:8])
-        return cached[1]
+    if cached:
+        stored_at, vector, pinned = cached
+        if pinned or (now - stored_at) < _CURSOR_TTL_SECONDS:
+            logger.debug("voyage cache hit q_hash=%s pinned=%s", h[:8], pinned)
+            return vector
     t0 = time.monotonic()
     result = voyage.embed_query(q)
     logger.info(
@@ -104,8 +111,57 @@ def _cached_query_vector(voyage: VoyageClient, q: str) -> list[float]:
         int((time.monotonic() - t0) * 1000),
         h[:8],
     )
-    _QUERY_VEC_CACHE[h] = (now, result.vector)
+    _QUERY_VEC_CACHE[h] = (now, result.vector, False)
     return result.vector
+
+
+def warm_query_cache(
+    voyage: VoyageClient | None, queries: list[str] | None = None
+) -> int:
+    """Pre-embed the popular hero-search queries and PIN them in the cache (#253).
+
+    Called once at API startup (off the request path) so the first semantic
+    search after a deploy doesn't pay the cold ~1.4-1.9s Voyage embed. One
+    batched Voyage call covers the whole seed list. Pinned entries never expire,
+    so a popular query stays warm even past the 5-minute TTL.
+
+    Returns the number of queries warmed (0 if Voyage is unavailable). Never
+    raises — a warming failure must never block startup or the request path; the
+    queries simply stay cold and embed lazily on first use, exactly as before.
+    """
+    if voyage is None:
+        logger.info("voyage warm-cache skipped: client unavailable")
+        return 0
+    if queries is None:
+        from core.agent.popular_queries import popular_queries
+
+        queries = popular_queries()
+    # Only embed the ones not already pinned (idempotent across re-runs/tests).
+    pending = [
+        q
+        for q in queries
+        if not (
+            (e := _QUERY_VEC_CACHE.get(hashlib.sha256(q.encode()).hexdigest())) and e[2]
+        )
+    ]
+    if not pending:
+        return 0
+    try:
+        t0 = time.monotonic()
+        results = voyage.embed(pending, input_type="query")
+        now = time.time()
+        for q, res in zip(pending, results):
+            h = hashlib.sha256(q.encode()).hexdigest()
+            _QUERY_VEC_CACHE[h] = (now, res.vector, True)
+        logger.info(
+            "voyage warm-cache pinned=%d duration_ms=%d",
+            len(results),
+            int((time.monotonic() - t0) * 1000),
+        )
+        return len(results)
+    except Exception as exc:
+        logger.warning("voyage warm-cache failed (queries stay cold): %r", exc)
+        return 0
 
 
 # ── Search engine ────────────────────────────────────────────────────────────

--- a/tests/unit/agent/test_batch_interpret.py
+++ b/tests/unit/agent/test_batch_interpret.py
@@ -1,0 +1,111 @@
+"""#411 — token-interpretation cache-warm batch.
+
+Covers the candidate-selection SQL shape, the surfaceless/skip-cached gating,
+and the cmd_interpret warm loop (mocked agent_service so no Claude call).
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+from core.agent.batch import (
+    _INTERPRET_PROMPT_VERSION,
+    _fetch_interpret_candidates,
+    cmd_interpret,
+    main,
+)
+
+
+def _fake_conn(rows):
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.__enter__ = lambda s: s
+    cur.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def test_fetch_candidates_surfaceless_and_skip_cached():
+    """surfaceless_only adds the surface_id IS NULL gate; skip_cached adds the
+    NOT EXISTS against the token_interpretation cache with the right prompt ver."""
+    conn, cur = _fake_conn([{"p_number": "P1", "token_id": 7}])
+    out = _fetch_interpret_candidates(
+        conn, limit=50, surfaceless_only=True, skip_cached=True
+    )
+    assert out == [("P1", 7)]
+    sql, params = cur.execute.call_args[0]
+    assert "tl.surface_id IS NULL" in sql
+    assert "token_interpretation" in sql
+    assert "lemmatizations lz" in sql
+    assert _INTERPRET_PROMPT_VERSION in params
+    assert params[-1] == 50  # LIMIT bound last
+
+
+def test_fetch_candidates_no_gates_when_flags_off():
+    conn, cur = _fake_conn([])
+    _fetch_interpret_candidates(
+        conn, limit=10, surfaceless_only=False, skip_cached=False
+    )
+    sql, params = cur.execute.call_args[0]
+    assert "tl.surface_id IS NULL" not in sql
+    assert "NOT EXISTS" not in sql
+    assert params == [10]  # only LIMIT
+
+
+def test_cmd_interpret_warms_each_candidate():
+    """cmd_interpret calls do_interpret_token once per candidate (the warm pass)."""
+    args = argparse.Namespace(
+        limit=2, surfaceless_only=True, skip_cached=True, dry_run=False
+    )
+    chain = MagicMock()
+    chain.steps = [MagicMock()]
+    chain.hypotheses = None
+    resp = MagicMock(data=chain)
+
+    with (
+        patch("core.agent.batch.connect_one_shot") as conn_factory,
+        patch("core.agent.batch.get_settings") as settings,
+        patch(
+            "core.agent.batch._fetch_interpret_candidates",
+            return_value=[("P1", 1), ("P2", 2)],
+        ),
+        patch("api.services.agent_service.do_interpret_token", return_value=resp) as di,
+        patch("core.agent.batch.time.sleep"),
+    ):
+        settings.return_value.anthropic_api_key = "sk-test"
+        conn_factory.return_value = MagicMock()
+        rc = cmd_interpret(args)
+
+    assert rc == 0
+    assert di.call_count == 2
+
+
+def test_cmd_interpret_dry_run_makes_no_calls():
+    args = argparse.Namespace(
+        limit=5, surfaceless_only=True, skip_cached=True, dry_run=True
+    )
+    with (
+        patch("core.agent.batch.connect_one_shot", return_value=MagicMock()),
+        patch("core.agent.batch.get_settings"),
+        patch(
+            "core.agent.batch._fetch_interpret_candidates",
+            return_value=[("P1", 1)],
+        ),
+        patch("api.services.agent_service.do_interpret_token") as di,
+    ):
+        rc = cmd_interpret(args)
+    assert rc == 0
+    di.assert_not_called()
+
+
+def test_interpret_subcommand_is_wired():
+    """The `interpret` subcommand routes to cmd_interpret."""
+    with patch("core.agent.batch.cmd_interpret", return_value=0) as ci:
+        rc = main(["interpret", "--limit", "3"])
+    assert rc == 0
+    ci.assert_called_once()
+    ns = ci.call_args[0][0]
+    assert ns.limit == 3
+    assert ns.surfaceless_only is True

--- a/tests/unit/agent/test_search_engine_timing.py
+++ b/tests/unit/agent/test_search_engine_timing.py
@@ -287,3 +287,66 @@ def test_rrf_score_increases_with_dual_list_presence():
     fused = engine._rrf([[shared, lex_only], [shared, sem_only]])
     ids = [h.entity_id for h in fused]
     assert ids[0] == "P_BOTH"
+
+
+# ── #253 popular-query warm cache ─────────────────────────────────────────────
+
+
+def test_warm_query_cache_pins_and_skips_cold_embed():
+    """warm_query_cache pre-embeds queries and PINS them so a later lookup is a
+    hit with no further embed call (#253: kills the cold ~1.4-1.9s hero path)."""
+    from core.agent.search_engine import warm_query_cache
+
+    _QUERY_VEC_CACHE.clear()
+    voyage = MagicMock()
+    voyage.embed.return_value = [
+        MagicMock(vector=[0.1, 0.2, 0.3]),
+        MagicMock(vector=[0.4, 0.5, 0.6]),
+    ]
+    n = warm_query_cache(voyage, queries=["barley rations", "royal inscriptions"])
+    assert n == 2
+    assert voyage.embed.call_count == 1  # ONE batched call for the whole list
+
+    # A subsequent lookup is a pinned hit — embed_query must never be called.
+    vec = _cached_query_vector(voyage, "barley rations")
+    assert vec == [0.1, 0.2, 0.3]
+    voyage.embed_query.assert_not_called()
+
+
+def test_warm_query_cache_pin_survives_ttl():
+    """A pinned entry must NOT expire after the 5-minute TTL (#253)."""
+    import hashlib
+
+    from core.agent.search_engine import warm_query_cache
+
+    _QUERY_VEC_CACHE.clear()
+    voyage = MagicMock()
+    voyage.embed.return_value = [MagicMock(vector=[0.7, 0.8, 0.9])]
+    warm_query_cache(voyage, queries=["land sale"])
+
+    # Force the stored timestamp far into the past (well past the TTL).
+    h = hashlib.sha256("land sale".encode()).hexdigest()
+    stored_at, vector, pinned = _QUERY_VEC_CACHE[h]
+    _QUERY_VEC_CACHE[h] = (stored_at - 10_000, vector, pinned)
+
+    vec = _cached_query_vector(voyage, "land sale")  # still a hit
+    assert vec == [0.7, 0.8, 0.9]
+    voyage.embed_query.assert_not_called()
+
+
+def test_warm_query_cache_no_voyage_is_noop():
+    """No Voyage client → warm pass is a safe no-op returning 0 (never raises)."""
+    from core.agent.search_engine import warm_query_cache
+
+    _QUERY_VEC_CACHE.clear()
+    assert warm_query_cache(None) == 0
+
+
+def test_warm_query_cache_swallows_embed_failure():
+    """A Voyage hiccup during warming must not raise — queries just stay cold."""
+    from core.agent.search_engine import warm_query_cache
+
+    _QUERY_VEC_CACHE.clear()
+    voyage = MagicMock()
+    voyage.embed.side_effect = RuntimeError("voyage down")
+    assert warm_query_cache(voyage, queries=["letters"]) == 0


### PR DESCRIPTION
Perf batch — three independent latency wins, no migration, no schema change.

## #115 — parallelize sequential tablet-list API calls
`tablet_list` fired its independent API round trips sequentially (list_artifacts + timeline + by-site, plus site-coords on the map view). Now concurrent via `ThreadPoolExecutor` (same pattern as `core/agent/search_engine.py`). `httpx.Client` is thread-safe and every `api.*` method already degrades to empty, so the page renders **identically** — just at MAX(call) latency instead of SUM.
- **Before/after (timing model, 3 calls @ 180/120/100ms): 428ms -> 196ms (~54% faster).** All tablet/list/route tests pass; `/tablets` and `/tablets?view=map` render 200.

## #253 — warm + pin the popular query-embed cache
The in-process Voyage query-embed cache clears on every process restart, so the first hero search after a deploy paid the cold ~1.4-1.9s embed. Added a curated popular-query seed (`core/agent/popular_queries.py`), a `warm_query_cache()` pass that batches them into **one** embed at API startup (off the request path, daemon thread), and **pins** those entries so they survive the 5-min TTL.
- **Before/after (1.6s cold embed model): cold 1605ms -> warm 0.09ms on the hero path.** Warm pass is one batched call at startup. New unit tests cover pin/TTL-survival/no-voyage/failure-swallow.

## #411 — warm the interpret_token cache for the surfaceless lines
Cold `interpret_token` is a 30-45s Claude chain on a cache miss — the UX risk on the newly-unlocked 264k surface-less lines (#407). Added a batch interpret warm-cache pass (CLI `python -m core.agent.batch interpret` + `POST /agentic/batch/interpret`) mirroring the existing summarize batch. Pre-runs `do_interpret_token` for lemmatized tokens, **defaulting to the surface-less #407 risk surface**, so the first user interpret is a warm `agent_outputs` hit. Same lazy-persist path as a live request — no parallel cache. Chose the pragmatic cache-warm over an async/poll UX rework (the bigger option).
- Idempotent (`--skip-cached` default), resumable. Unit tests cover candidate SQL gating, the warm loop, dry-run, and CLI wiring.

## Gate
ruff + ruff format + mypy (136 files) clean; 426 pytest pass / 40 DB-integration skipped; 8 JS tests pass. **No migrations touched in this branch.**

## Operate after merge (#253/#411)
- #253 warms automatically at API startup — no action.
- #411: run `python -m core.agent.batch interpret --limit N` on the VPS (or `POST /agentic/batch/interpret`) to seed the surface-less token cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)