### PR TITLE
viz: timeline period-label collision handling + long-running ops runbook (#217 #275)

### DIFF
--- a/app/static/js/transmission-timeline.js
+++ b/app/static/js/transmission-timeline.js
@@ -212,7 +212,7 @@ TransmissionTimeline.prototype._render = function () {
     var paddingTop = 12;
     var trackHeight = 80;      // dot area height
     var axisHeight = 18;       // BCE tick axis below the track
-    var labelHeight = 28;      // period label area below the axis
+    var labelHeight = 40;      // period label area below the axis (2 staggered rows)
     var svgHeight = paddingTop + trackHeight + axisHeight + labelHeight + 8;
 
     // viewBox approach so it scales with container width
@@ -443,16 +443,83 @@ TransmissionTimeline.prototype._render = function () {
     var labelsG = document.createElementNS(SVG_NS, 'g');
     labelsG.setAttribute('class', 'tl-labels');
 
-    orderedPeriods.forEach(function (period) {
+    // Label-collision handling. Period bands get narrow and crowd on the dense
+    // right edge (Neo-/Late-Babylonian, Achaemenid, Seleucid, Parthian sit in a
+    // ~500-year sliver). With no thinning their centred names overlap into an
+    // illegible smear. We:
+    //   1. truncate long names (and truncate harder when the band is narrow),
+    //   2. estimate each label's footprint and stagger alternates onto a second
+    //      row when a neighbour would overlap, and
+    //   3. as a last resort drop (thin) a label that still collides on its row,
+    // so every rendered label is legible. Anchoring stays centred on the band
+    // midpoint, but the midpoint is clamped so edge labels never spill outside
+    // the viewBox.
+    var CHAR_W = 4.6;          // approx px per char at 9px font in viewBox units
+    var LABEL_GAP = 6;         // min horizontal gap between labels on the same row
+    var labelRowY = [
+        axisY + axisHeight + 11,   // row 0 (upper)
+        axisY + axisHeight + 24,   // row 1 (lower, staggered)
+    ];
+
+    // Build the candidate labels first, with their clamped centre and estimated
+    // footprint, then sort LEFT-TO-RIGHT by screen x before the collision walk.
+    // Sorting by x (not chronology) matters: the BCE axis runs oldest-on-the-
+    // right, so chronological order is right-to-left on screen — walking it
+    // directly would mis-detect every overlap. We sort by x so the greedy
+    // "does this start after the last one ended?" test is correct.
+    var labelCandidates = orderedPeriods.map(function (period) {
         var range = self._ranges[period];
-        var midX;
+        var midX, bandW;
         if (range) {
-            midX = (yearToX(range[0]) + yearToX(range[1])) / 2;
+            var bx1 = yearToX(range[0]);
+            var bx2 = yearToX(range[1]);
+            midX = (bx1 + bx2) / 2;
+            bandW = Math.abs(bx2 - bx1);
         } else {
             midX = paddingLeft + trackWidth - 20;
+            bandW = 40;
         }
 
-        var labelY = axisY + axisHeight + labelHeight - 6;
+        // Truncate: long names always; narrow bands harder so a tight cluster
+        // of short labels has a chance to sit side-by-side without overlapping.
+        var maxChars = bandW < 70 ? 9 : 14;
+        var shortName = period.length > maxChars
+            ? period.substring(0, maxChars - 1) + '…'
+            : period;
+
+        var halfW = (shortName.length * CHAR_W) / 2;
+
+        // Clamp the label centre so it stays fully inside the drawable width.
+        var minX = paddingLeft + halfW;
+        var maxX = paddingLeft + trackWidth - halfW;
+        if (midX < minX) midX = minX;
+        if (midX > maxX) midX = maxX;
+
+        return { period: period, shortName: shortName, midX: midX, halfW: halfW };
+    }).sort(function (a, b) { return a.midX - b.midX; });
+
+    // Track the right edge of the last placed label per row, for collision tests.
+    var rowRightEdge = [-Infinity, -Infinity];
+
+    labelCandidates.forEach(function (cand) {
+        var period = cand.period;
+        var shortName = cand.shortName;
+        var midX = cand.midX;
+        var leftEdge = midX - cand.halfW;
+        var rightEdge = midX + cand.halfW;
+
+        // Pick a row: prefer the one whose last label ends before this one
+        // starts. Try row 0, then row 1.
+        var row = -1;
+        for (var r = 0; r < 2; r++) {
+            if (leftEdge - rowRightEdge[r] >= LABEL_GAP) { row = r; break; }
+        }
+        // Both rows still occupied at this x → thin (skip) this label so we
+        // never render an unreadable overlap. The period band + dots remain.
+        if (row === -1) return;
+
+        rowRightEdge[row] = rightEdge;
+        var labelY = labelRowY[row];
 
         var text = document.createElementNS(SVG_NS, 'text');
         text.setAttribute('x', midX);
@@ -463,10 +530,13 @@ TransmissionTimeline.prototype._render = function () {
         text.setAttribute('role', 'button');
         text.setAttribute('aria-pressed', 'false');
         text.setAttribute('data-period', period);
-        // Shorten very long period names
-        var shortName = period.length > 14 ? period.substring(0, 13) + '…' : period;
         text.textContent = shortName;
         text.style.cursor = 'pointer';
+        // Full name on hover (and for AT) so truncation/thinning loses no info.
+        var fullTitle = document.createElementNS(SVG_NS, 'title');
+        fullTitle.textContent = period;
+        text.appendChild(fullTitle);
+        text.setAttribute('aria-label', period);
 
         (function (p, textEl) {
             function selectPeriod(newPeriod) {

--- a/ops/deploy/DEPLOY.md
+++ b/ops/deploy/DEPLOY.md
@@ -2,11 +2,11 @@
 question: "How does Glintstone get from a git commit to a running release on the VPS?"
 created: 2026-05-11
 modified: 2026-06-23
-context: "Rewritten 2026-05-12 to reflect post-VPS-cutover reality: production Postgres lives on the VPS itself (Neon decommissioned), migrations run server-side, and the branch model is `staging` → `main` with an approval gate on production. 2026-06-23 (#219/#272): pre-deploy pg_dump now skipped on code-only deploys and parallelised (-Fd -j4) when it runs."
+context: "Rewritten 2026-05-12 to reflect post-VPS-cutover reality: production Postgres lives on the VPS itself (Neon decommissioned), migrations run server-side, and the branch model is `staging` → `main` with an approval gate on production. 2026-06-23 (#219/#272): pre-deploy pg_dump now skipped on code-only deploys and parallelised (-Fd -j4) when it runs. 2026-06-23 (#275): added the long-running ingestion / DLQ-replay section — run multi-minute ops under nohup/setsid so SIGHUP on SSH disconnect can't kill them mid-stream."
 status: active
 audience: [engineers, ops, claude]
 owners: [eric]
-related_issues: ["#14", "#52", "#61", "#219", "#272"]
+related_issues: ["#14", "#52", "#61", "#219", "#272", "#273", "#275"]
 related_skills: [gs-expert-deployment]
 supersedes: null
 superseded_by: null
@@ -215,6 +215,60 @@ git checkout -b hotfix-something main
 
 The production approval gate still fires. Cost: you've bypassed the staging
 soak. Reserve for genuine emergencies.
+
+### Long-running ingestion / DLQ replay
+
+Ingestion runs, dead-letter (DLQ) replays, and bulk backfills can take many
+minutes — sometimes hours (a GeoNames load or a multi-million-row DLQ replay).
+If you start one in a plain SSH session and the connection drops — laptop
+sleeps, Wi-Fi blips, you close the lid — the shell receives **SIGHUP** and
+kills the process *and its whole pipeline* mid-stream. We learned this the hard
+way (#273): a `ssh … | tail` DLQ replay got SIGHUP'd at ~70K of 4.87M rows when
+the pipe stalled, and had to be re-run.
+
+**Rule: any op expected to outlive an SSH session runs detached.** Use `nohup`
+(or `setsid`) so SIGHUP can't reach it, redirect output to a log file, and tail
+the log instead of holding the process open through the pipe.
+
+#### Pattern A — `nohup … &` (the default, simplest)
+
+```bash
+# On the VPS, from the app root (/var/www/glintstone/current):
+nohup python -m ingestion.cli dead-letters replay --source geonames \
+  > /var/www/glintstone/shared/logs/dlq-replay-$(date +%F).log 2>&1 &
+echo "started PID $!"          # note the PID so you can check on it later
+
+# Now it's safe to disconnect. To watch progress, re-attach and tail the log:
+tail -f /var/www/glintstone/shared/logs/dlq-replay-*.log
+
+# Check it's still alive / see it finish:
+ps -p <PID>                     # empty output = it exited
+```
+
+Why it works: `nohup` makes the process ignore SIGHUP, the `> … 2>&1`
+redirect detaches stdout/stderr from the terminal (so a closed pipe can't stall
+or kill it), and trailing `&` backgrounds it so your shell returns immediately.
+
+#### Pattern B — `setsid` (fully detached, survives even `kill -HUP` of the shell)
+
+```bash
+setsid python -m ingestion.cli run --source geonames \
+  > /var/www/glintstone/shared/logs/geonames-ingest-$(date +%F).log 2>&1 < /dev/null
+# returns immediately; the process is in its own session with no controlling
+# terminal, so nothing the SSH session does can signal it. tail the log as above.
+```
+
+Use **B** when you want the job in its own session (no chance of inheriting a
+signal from the parent shell at all); **A** is fine for everything routine.
+
+**Do / don't**
+- **Do** redirect to a log under `shared/logs/` and `tail -f` it — never pipe a
+  long run straight into `tail`/`grep` over SSH (a stalled pipe is exactly what
+  bit us in #273).
+- **Do** record the PID (`echo $!`) and the log path before you walk away.
+- **Don't** run a multi-minute ingestion/replay in a bare foreground SSH shell.
+- **Don't** assume `tmux`/`screen` is installed on the VPS — `nohup`/`setsid`
+  are always present and need no session to stay attached to.
 
 ## Required GitHub configuration
 


### PR DESCRIPTION
Two small items, one worktree/PR.

## #217 — Period-label collision handling (Transmission timeline)
The bottom-row period-NAME labels had no collision detection, so dense late spans (Neo-/Late-Babylonian, Achaemenid, Seleucid, Parthian — all in a ~500-year BCE-edge sliver) overlapped into an illegible smear. The #320 Atlas work added bar-overflow clamping + BCE tick collision detection, but never touched the period names.

**Fix:** thinning + two-row staggering. Build label candidates with clamped centres and estimated footprints, **sort left-to-right by screen x** (the BCE axis runs oldest-on-the-right, so chronological order is right-to-left — sorting by x is what makes the greedy overlap test correct), then place each on the upper row or a staggered lower row; truncate narrow-band names harder, and drop a label only as a last resort. Full name preserved via `<title>` + `aria-label`. `labelHeight` 28→40 for the second row.

**Render-verified** (headless Chrome, real `transmission-timeline.js`):
- Desktop 1000px: all dated labels legible, dense BCE edge staggered/truncated, fully-overlapped Hellenistic thinned.
- 390px: existing `<480px` mobile fallback shows the full-name period+count list — unaffected, every late period legible.

## #275 — Long-running ingestion / DLQ replay runbook (doc-only)
New DEPLOY.md section: run multi-minute ingestion / DLQ replays under `nohup … &` (Pattern A) or `setsid` (Pattern B) so a SIGHUP on SSH disconnect can't kill them mid-stream. Concrete geonames / dlq-replay examples, log-to-file + `tail -f` guidance, and the #273 post-mortem (a `ssh|tail` replay died at ~70K/4.87M when the pipe stalled).

## Gate
ruff ✓ · ruff format ✓ · mypy (136 files) ✓ · JS tests (8) ✓ · pytest (429 passed, 40 integration skipped — no DB in this env) ✓

Code-only / doc-only → fast deploy, pre-deploy pg_dump skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)