### PR TITLE
fix(#450): avatar persists across page reload

### DIFF
--- a/api/repositories/session_repo.py
+++ b/api/repositories/session_repo.py
@@ -47,7 +47,10 @@ class SessionRepository(BaseRepository):
                 u.email,
                 u.display_name,
                 u.orcid_id,
-                u.email_verified_at
+                u.email_verified_at,
+                u.avatar_url,
+                u.role,
+                u.theme
             FROM user_sessions s
             JOIN users u ON u.id = s.user_id
             WHERE s.token_hash = %(token_hash)s

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -162,6 +162,35 @@ class TestSessionRepo:
 
         assert session_repo.find_by_token_hash(token_hash) is None
 
+    def test_session_lookup_returns_avatar_url(
+        self, test_user, user_repo, session_repo, db_conn
+    ):
+        """Regression for #450: an avatar set on the user must survive a page
+        reload. On reload the browser re-authenticates via the session cookie,
+        so the session→user join is the read path. It previously dropped
+        avatar_url (also role/theme), so the saved avatar vanished after refresh.
+        """
+        from datetime import datetime, timedelta, timezone
+        from api.services.auth_service import generate_session_token, hash_token
+
+        avatar_url = f"https://pub-test.r2.dev/avatars/{test_user['id']}.jpg"
+        user_repo.update_avatar_url(test_user["id"], avatar_url)
+        db_conn.commit()
+
+        raw = generate_session_token()
+        token_hash = hash_token(raw)
+        expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+        session_repo.create_session(test_user["id"], token_hash, expires_at)
+        db_conn.commit()
+
+        row = session_repo.find_by_token_hash(token_hash)
+        assert row is not None
+        # The read-back the middleware relies on must carry the persisted avatar.
+        assert row["avatar_url"] == avatar_url
+        # role + theme rode the same missing-column bug; assert they survive too.
+        assert "role" in row
+        assert "theme" in row
+
 
 class TestApiKeyRepo:
     def test_create_and_find(self, test_user, api_key_repo, db_conn):


### PR DESCRIPTION
## Problem
Eric reported (#450): "when I add an avatar, it doesn't save after I refresh the page."

## Root cause
The avatar upload path was correct end-to-end: `POST /auth/avatar` writes the image to storage (R2/local) **and** the `users.avatar_url` column, commits, and returns the URL. The bug was on the **read** path.

On every page load the browser re-authenticates via the `session_token` cookie. The auth middleware builds `request.state.user` from `SessionRepository.find_by_token_hash()` — a session→user join. That SELECT only pulled `email, display_name, orcid_id, email_verified_at`; it **omitted `avatar_url`** (and `role`, `theme`). So `/auth/me` returned `avatar_url: None` after a refresh and the header/account UI fell back to the initial. The avatar *was* saved in the database the whole time — the read query dropped the column.

(The API-key auth path reloads the full user row via `find_by_id`, so it was unaffected; only the cookie/Bearer browser path — i.e. the actual user flow — was broken. `theme` rode the same bug but was masked by its cookie fallback.)

## Fix
Add `avatar_url`, `role`, `theme` to the session-join SELECT in `api/repositories/session_repo.py`. No migration — all three columns already exist (migrations 029/037/038).

## Regression test
`TestSessionRepo::test_session_lookup_returns_avatar_url`: set an avatar, create a session, assert the session-join read-back returns it. Verified it **fails** (`KeyError: 'avatar_url'`) without the SELECT change and **passes** with it.

## Verification
ruff + mypy clean. Session/auth repo tests pass against a real Postgres 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)