### PR TITLE
feat(#129): per-surface image serving + overlay scaling (#310 confirmed no-change)

### DIFF
--- a/api/repositories/artifact_repo.py
+++ b/api/repositories/artifact_repo.py
@@ -796,15 +796,61 @@ class ArtifactRepository(BaseRepository):
         )
 
     def get_images(self, p_number: str) -> list[dict]:
+        """Per-surface image manifest.
+
+        Carries ``surface_image_id`` plus the stored ``image_width``/
+        ``image_height`` so the viewer can (a) request a specific surface's
+        image via ``/image/{p_number}?surface_image_id=...`` and (b) scale that
+        surface's sign-annotation overlays against the image's true pixel
+        dimensions instead of falling back to the browser's ``naturalWidth``
+        (#129). ``image_path`` ends in ``/Obv`` or ``/Rev`` — the reliable
+        obverse/reverse signal, since ``surface_type`` is unreliable in the
+        compvis source data.
+        """
         return self.fetch_all(
             """
-            SELECT s.surface_type, si.image_path, si.is_primary, si.image_type
+            SELECT si.id AS surface_image_id,
+                   s.surface_type, si.image_path, si.is_primary, si.image_type,
+                   si.image_width, si.image_height
             FROM surfaces s
             JOIN surface_images si ON s.id = si.surface_id
             WHERE s.p_number = %(p_number)s
-            ORDER BY si.is_primary DESC
+            ORDER BY si.is_primary DESC, si.id
         """,
             {"p_number": p_number},
+        )
+
+    def get_surface_image(self, surface_image_id: int) -> dict | None:
+        """Resolve a single surface_image row by id (#129 per-surface serving)."""
+        return self.fetch_one(
+            """
+            SELECT si.id AS surface_image_id, s.p_number, s.surface_type,
+                   si.image_path, si.image_width, si.image_height
+            FROM surface_images si
+            JOIN surfaces s ON si.surface_id = s.id
+            WHERE si.id = %(id)s
+            """,
+            {"id": surface_image_id},
+        )
+
+    def set_surface_image_dimensions(
+        self, surface_image_id: int, width: int, height: int
+    ) -> None:
+        """Persist measured pixel dimensions for a surface image (#129).
+
+        Lazy backfill: the first time the image-serving route opens a surface
+        image whose ``image_width``/``image_height`` are NULL, it measures the
+        bytes and writes them back here so subsequent overlay scaling is
+        precise without re-measuring. Idempotent — only fills NULLs.
+        """
+        self.execute(
+            """
+            UPDATE surface_images
+            SET image_width = %(w)s, image_height = %(h)s
+            WHERE id = %(id)s
+              AND (image_width IS NULL OR image_height IS NULL)
+            """,
+            {"w": width, "h": height, "id": surface_image_id},
         )
 
     def get_artifact_image_records(self, p_number: str) -> list[dict]:
@@ -1165,11 +1211,21 @@ class ArtifactRepository(BaseRepository):
     # ── Sign annotations (OCR overlay) ───────────────────────
 
     def get_sign_annotations(self, p_number: str) -> dict:
-        """Return sign annotations for the overlay viewer."""
+        """Return sign annotations for the overlay viewer.
+
+        Each row carries its ``surface_image_id`` and that surface image's
+        ``image_width``/``image_height`` (#129). Bounding boxes are stored in
+        the absolute pixel space of their own surface image (obverse and
+        reverse have different dimensions), so the viewer must scale each
+        surface's boxes against that surface's image — not one global
+        ``naturalWidth``. When the stored dimensions are NULL the viewer falls
+        back to the loaded image's natural size for that surface.
+        """
         rows = self.fetch_all(
             """
             SELECT sa.sign_id, sa.token_id, sa.bbox_x, sa.bbox_y, sa.bbox_w, sa.bbox_h,
-                   sa.confidence, s.surface_type
+                   sa.confidence, s.surface_type,
+                   sa.surface_image_id, si.image_width, si.image_height
             FROM sign_annotations sa
             JOIN surface_images si ON sa.surface_image_id = si.id
             JOIN surfaces s ON si.surface_id = s.id

--- a/api/routes/artifacts.py
+++ b/api/routes/artifacts.py
@@ -264,6 +264,48 @@ def get_artifact_images(p_number: str, conn=Depends(get_db)):
     }
 
 
+@router.get("/{p_number}/surface-images")
+def get_surface_images(p_number: str, conn=Depends(get_db)):
+    """Per-surface image manifest for the tablet viewer (#129).
+
+    Each entry is one physical surface image (obverse, reverse, …) with the
+    ``surface_image_id`` the viewer passes to ``/image/{p}?surface_image_id=``
+    and the stored pixel ``width``/``height`` used to scale that surface's
+    sign-annotation overlays. ``surface`` is derived from the image path
+    (``…/Obv`` → obverse, ``…/Rev`` → reverse) because the source
+    ``surface_type`` column is unreliable. Dimensions may be ``null`` until the
+    serving path backfills them on first view — the viewer then falls back to
+    the loaded image's natural size for that surface.
+    """
+    repo = ArtifactRepository(conn)
+    rows = repo.get_images(p_number)
+
+    def _surface_label(row: dict) -> str:
+        path = (row.get("image_path") or "").rstrip("/")
+        tail = path.rsplit("/", 1)[-1].lower()
+        if tail.startswith("obv"):
+            return "obverse"
+        if tail.startswith("rev"):
+            return "reverse"
+        return row.get("surface_type") or "surface"
+
+    return {
+        "p_number": p_number,
+        "count": len(rows),
+        "surfaces": [
+            {
+                "surface_image_id": r["surface_image_id"],
+                "surface": _surface_label(r),
+                "is_primary": bool(r.get("is_primary")),
+                "image_type": r.get("image_type"),
+                "width": r.get("image_width"),
+                "height": r.get("image_height"),
+            }
+            for r in rows
+        ],
+    }
+
+
 @router.get("/{p_number}/normalized")
 def get_artifact_normalized(p_number: str, conn=Depends(get_db)):
     """Get normalized readings (scholarly transliteration) for an artifact."""

--- a/api/routes/image.py
+++ b/api/routes/image.py
@@ -1,4 +1,18 @@
-"""GET /image/{p_number} — Tablet image serving with thumbnail support."""
+"""GET /image/{p_number} — Tablet image serving with thumbnail support.
+
+Per-surface serving (#129): pass ``?surface_image_id=<id>`` (the id from the
+artifact's image manifest, ``GET /artifacts/{p}/images`` /
+``ArtifactRepository.get_images``) to serve a *specific* surface's image —
+obverse, reverse, etc. — rather than the artifact's single primary image.
+Each surface image has its own pixel dimensions, and sign-annotation bounding
+boxes are stored in their own surface image's coordinate space, so the viewer
+must request and scale each surface independently.
+
+When a surface image's ``image_width``/``image_height`` are still NULL, the
+serving path measures the bytes once and writes them back (lazy backfill) so
+subsequent overlay scaling is precise without relying on the browser's
+``naturalWidth``.
+"""
 
 from pathlib import Path
 
@@ -13,6 +27,23 @@ from api.repositories.artifact_repo import ArtifactRepository
 router = APIRouter(tags=["images"])
 
 
+def _resolve_path(image_dir: Path, image_path: str) -> Path | None:
+    """Resolve a stored ``image_path`` to a real file on disk.
+
+    ``surface_images.image_path`` may name either a file or a directory (the
+    compvis source stores ``compvis/<P>/Obv`` style directory references). For
+    a directory we take the first image file inside it.
+    """
+    candidate = image_dir / image_path
+    if candidate.is_file():
+        return candidate
+    if candidate.is_dir():
+        for child in sorted(candidate.iterdir()):
+            if child.suffix.lower() in (".jpg", ".jpeg", ".png", ".tif", ".tiff"):
+                return child
+    return None
+
+
 def _find_image(p_number: str, conn) -> Path | None:
     """Resolve image path: surface_images table → filesystem → None."""
     settings = get_settings()
@@ -23,9 +54,9 @@ def _find_image(p_number: str, conn) -> Path | None:
     images = repo.get_images(p_number)
     for img in images:
         if img.get("image_path"):
-            candidate = image_dir / img["image_path"]
-            if candidate.exists():
-                return candidate
+            resolved = _resolve_path(image_dir, img["image_path"])
+            if resolved is not None:
+                return resolved
 
     # 2. Filesystem fallback: {image_path}/{p_number}.jpg
     for ext in (".jpg", ".jpeg", ".png"):
@@ -34,6 +65,37 @@ def _find_image(p_number: str, conn) -> Path | None:
             return candidate
 
     return None
+
+
+def _find_surface_image(surface_image_id: int, conn) -> Path | None:
+    """Resolve a specific surface image's file, backfilling its dimensions.
+
+    Returns the file path for the given ``surface_image_id``, and — when the
+    row's stored dimensions are NULL — measures the image once and persists
+    ``image_width``/``image_height`` back to ``surface_images`` (#129).
+    """
+    settings = get_settings()
+    image_dir = Path(settings.image_path)
+    repo = ArtifactRepository(conn)
+
+    row = repo.get_surface_image(surface_image_id)
+    if not row or not row.get("image_path"):
+        return None
+
+    resolved = _resolve_path(image_dir, row["image_path"])
+    if resolved is None:
+        return None
+
+    if row.get("image_width") is None or row.get("image_height") is None:
+        try:
+            with Image.open(resolved) as img:
+                width, height = img.size
+            repo.set_surface_image_dimensions(surface_image_id, width, height)
+        except Exception:
+            # Measuring is best-effort; serving still succeeds without it.
+            pass
+
+    return resolved
 
 
 def _get_thumbnail(source: Path, size: int) -> Path:
@@ -60,8 +122,16 @@ def _get_thumbnail(source: Path, size: int) -> Path:
 
 
 @router.get("/image/{p_number}")
-def get_image(p_number: str, size: int | None = None, conn=Depends(get_db)):
-    source = _find_image(p_number, conn)
+def get_image(
+    p_number: str,
+    size: int | None = None,
+    surface_image_id: int | None = None,
+    conn=Depends(get_db),
+):
+    if surface_image_id is not None:
+        source = _find_surface_image(surface_image_id, conn)
+    else:
+        source = _find_image(p_number, conn)
 
     if source is None:
         raise HTTPException(status_code=404, detail="Image not found")

--- a/app/static/css/pages/tablets.css
+++ b/app/static/css/pages/tablets.css
@@ -1812,6 +1812,34 @@ body.page-tablet-detail > .page-header {
     min-height: 0;
 }
 
+/* Per-surface image selector (#129) — obverse / reverse switch above the
+   viewer. Hidden via [hidden] when the tablet has a single surface. */
+.image-surface-selector {
+    display: flex;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
+}
+
+.image-surface-selector__btn {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+}
+
+.image-surface-selector__btn:hover {
+    color: var(--color-text);
+}
+
+.image-surface-selector__btn[aria-pressed="true"] {
+    color: var(--color-text);
+    border-color: var(--color-accent);
+    background: var(--color-surface-raised, var(--color-surface));
+}
+
 /* ==========================================================================
    #404 Concept B — sibling-witness strip + coverage chip on the tablet page.
    Finishes the composite-panel reverse link (the old "Loading tablets…"

--- a/app/static/js/tablet-detail.js
+++ b/app/static/js/tablet-detail.js
@@ -126,15 +126,14 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
 
-        // Load image from API
+        // Load image from API. Per-surface (#129): fetch the surface manifest
+        // first so we can offer an obverse/reverse selector and serve+scale
+        // each surface independently. Falls back to the single primary image
+        // when the manifest is empty or unavailable.
         const apiUrl = TabletPage.apiUrl;
         const pNumber = TabletPage.pNumber;
         if (apiUrl && pNumber) {
-            TabletPage.zoombox.loadImage({
-                local: `${apiUrl}/image/${pNumber}`,
-                cdliPhoto: `https://cdli.earth/dl/photo/${pNumber}.jpg`,
-                cdliLineart: `https://cdli.earth/dl/lineart/${pNumber}.jpg`
-            });
+            initSurfaceImages(apiUrl, pNumber);
         }
     }
 
@@ -215,36 +214,150 @@ document.addEventListener('DOMContentLoaded', function() {
 
 });
 
-// Load sign annotations (OCR overlay) after image loads
+// Per-surface image state (#129). The viewer shows ONE surface at a time;
+// each surface image has its own pixel dimensions and its sign-annotation
+// bounding boxes live in that surface's coordinate space. We cache the
+// annotations once and re-render the overlays for whichever surface is active,
+// scaling each box against that surface's stored width/height (or, when the
+// dimensions are still NULL in the database, the loaded image's natural size).
+const SurfaceState = {
+    surfaces: [],           // [{ surface_image_id, surface, width, height, ... }]
+    activeId: null,         // active surface_image_id
+    annotations: null,      // cached sign-annotation rows from the API
+};
+
+// Resolve the surface manifest, render a selector when there are 2+ surfaces,
+// and load the active surface's image. Falls back to the single primary image
+// when no surface manifest exists.
+function initSurfaceImages(apiUrl, pNumber) {
+    fetch(`${apiUrl}/artifacts/${pNumber}/surface-images`)
+        .then(r => r.ok ? r.json() : { surfaces: [] })
+        .catch(() => ({ surfaces: [] }))
+        .then(data => {
+            SurfaceState.surfaces = (data && data.surfaces) || [];
+            if (SurfaceState.surfaces.length === 0) {
+                // No per-surface data — serve the artifact's primary image.
+                loadActiveSurfaceImage();
+                return;
+            }
+            const primary = SurfaceState.surfaces.find(s => s.is_primary)
+                || SurfaceState.surfaces[0];
+            SurfaceState.activeId = primary.surface_image_id;
+            renderSurfaceSelector();
+            loadActiveSurfaceImage();
+        });
+}
+
+// Build the obverse/reverse (etc.) selector buttons. Hidden for a single
+// surface — there's nothing to switch.
+function renderSurfaceSelector() {
+    const host = document.getElementById('image-surface-selector');
+    if (!host) return;
+    if (SurfaceState.surfaces.length < 2) {
+        host.hidden = true;
+        return;
+    }
+    host.innerHTML = '';
+    host.hidden = false;
+    SurfaceState.surfaces.forEach(s => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'image-surface-selector__btn';
+        btn.textContent = s.surface.charAt(0).toUpperCase() + s.surface.slice(1);
+        btn.dataset.surfaceImageId = s.surface_image_id;
+        btn.setAttribute('aria-pressed', String(s.surface_image_id === SurfaceState.activeId));
+        btn.addEventListener('click', () => switchSurface(s.surface_image_id));
+        host.appendChild(btn);
+    });
+}
+
+function switchSurface(surfaceImageId) {
+    if (surfaceImageId === SurfaceState.activeId) return;
+    SurfaceState.activeId = surfaceImageId;
+    document.querySelectorAll('.image-surface-selector__btn').forEach(b => {
+        b.setAttribute('aria-pressed',
+            String(Number(b.dataset.surfaceImageId) === surfaceImageId));
+    });
+    loadActiveSurfaceImage();
+}
+
+// Load the active surface's image at its own dimensions. When a specific
+// surface is selected we ask the API for that surface_image_id; otherwise we
+// fall back to the artifact's primary image endpoint.
+function loadActiveSurfaceImage() {
+    const { apiUrl, pNumber, zoombox } = TabletPage;
+    if (!zoombox || !apiUrl || !pNumber) return;
+
+    let local = `${apiUrl}/image/${pNumber}`;
+    if (SurfaceState.activeId != null) {
+        local += `?surface_image_id=${SurfaceState.activeId}`;
+    }
+    zoombox.loadImage({
+        local,
+        cdliPhoto: `https://cdli.earth/dl/photo/${pNumber}.jpg`,
+        cdliLineart: `https://cdli.earth/dl/lineart/${pNumber}.jpg`
+    });
+}
+
+// Load sign annotations (OCR overlay) after image loads. Fetched once and
+// cached; re-rendered per active surface.
 function loadSignAnnotations() {
     const zoombox = TabletPage.zoombox;
     if (!zoombox || !zoombox.imageLoaded || !TabletPage.apiUrl || !TabletPage.pNumber) return;
 
+    if (SurfaceState.annotations) {
+        renderSurfaceOverlays();
+        return;
+    }
+
     fetch(`${TabletPage.apiUrl}/artifacts/${TabletPage.pNumber}/sign-annotations`)
         .then(r => r.json())
         .then(data => {
-            if (!data.annotations || data.annotations.length === 0) return;
-
-            const natW = zoombox.naturalWidth;
-            const natH = zoombox.naturalHeight;
-            if (!natW || !natH) return;
-
-            const overlays = data.annotations.map(a => ({
-                x: (a.bbox_x / natW) * 100,
-                y: (a.bbox_y / natH) * 100,
-                width: (a.bbox_w / natW) * 100,
-                height: (a.bbox_h / natH) * 100,
-                sign: a.sign_id || '',
-                surface: a.surface_type || '',
-                confidence: a.confidence || 0,
-                tokenId: a.token_id != null ? a.token_id : null
-            }));
-
-            zoombox.setOverlays(overlays);
+            SurfaceState.annotations = (data && data.annotations) || [];
+            renderSurfaceOverlays();
         })
         .catch(err => {
             console.log('Sign annotations not available:', err.message);
         });
+}
+
+// Render overlay boxes for the active surface only, scaling each box against
+// that surface's true pixel dimensions (#129). Bounding boxes are stored in
+// absolute pixels of their own surface image, so obverse and reverse must NOT
+// share one scale. We prefer the surface's stored width/height; when those are
+// still NULL we fall back to the loaded image's natural size.
+function renderSurfaceOverlays() {
+    const zoombox = TabletPage.zoombox;
+    if (!zoombox) return;
+    const annotations = SurfaceState.annotations || [];
+
+    // When there is no per-surface manifest, all boxes belong to the one image.
+    const activeId = SurfaceState.activeId;
+    const active = activeId != null
+        ? SurfaceState.surfaces.find(s => s.surface_image_id === activeId)
+        : null;
+
+    // Scale reference: stored surface dimensions, else loaded natural size.
+    const refW = (active && active.width) || zoombox.naturalWidth;
+    const refH = (active && active.height) || zoombox.naturalHeight;
+    if (!refW || !refH) return;
+
+    const forSurface = activeId != null
+        ? annotations.filter(a => a.surface_image_id === activeId)
+        : annotations;
+
+    const overlays = forSurface.map(a => ({
+        x: (a.bbox_x / refW) * 100,
+        y: (a.bbox_y / refH) * 100,
+        width: (a.bbox_w / refW) * 100,
+        height: (a.bbox_h / refH) * 100,
+        sign: a.sign_id || '',
+        surface: a.surface_type || '',
+        confidence: a.confidence || 0,
+        tokenId: a.token_id != null ? a.token_id : null
+    }));
+
+    zoombox.setOverlays(overlays);
 }
 
 // #404 Concept B — sibling-witness strip.

--- a/core/repository.py
+++ b/core/repository.py
@@ -34,6 +34,14 @@ class BaseRepository:
             # dict_row returns dict; get first value
             return next(iter(row.values()))
 
+    def execute(self, sql: str, params: dict | tuple = ()) -> int:
+        """Run a write statement, commit, and return the affected row count."""
+        with self.conn.cursor() as cur:
+            cur.execute(sql, params)
+            rowcount = cur.rowcount
+        self.conn.commit()
+        return rowcount
+
     @staticmethod
     def build_in_clause(values: list, prefix: str = "p") -> tuple[str, dict]:
         """Build IN clause with named parameters.


### PR DESCRIPTION
## #129 — Per-surface image serving

The tablet viewer served one primary image and scaled **every** sign-annotation overlay against that single image's \`naturalWidth\`. But obverse and reverse are distinct images with distinct pixel dimensions, and each surface's bounding boxes live in its own image's coordinate space — so reverse boxes rendered at the wrong scale on the obverse image (the "one-size assumption" #129 flagged).

**Backend (api)**
- New \`GET /artifacts/{p}/surface-images\` manifest: \`surface_image_id\` + stored \`image_width/height\`; surface label derived from the \`.../Obv|Rev\` path (\`surface_type\` is unreliable in the compvis source).
- \`get_sign_annotations\` now carries \`surface_image_id\` + dims per row.
- \`GET /image/{p}?surface_image_id=\` serves a specific surface; resolves directory-style compvis paths to a real file; **lazily backfills** \`image_width/height\` on first view.
- \`BaseRepository.execute()\` write helper.

**Frontend (app)**
- \`tablet-detail.js\`: fetch manifest, render obverse/reverse selector (hidden for single-surface), serve active surface by id, cache annotations once, re-render overlays filtered to the active surface, scaling each box against that surface's dims (fallback: loaded image natural size when dims NULL).
- \`tablets.css\`: tokenized \`.image-surface-selector\`.

No schema change (columns already existed) → no migration/GRANT.

## #310 — Competing-readings citation row decomposition

**Confirmed correct — no change.** \`buildCompetingTooltip\` already emits one \`<li>\` per reading, each with its own citation_form, guide_word, source (scholar) attribution, and confidence; the API \`get_competing_lemmas\` returns one row per distinct reading. Verified against the dev DB (P204982 etc.): each competing reading decomposes to its own attributed row.

## Verification
- ruff + mypy (api/app/core/mcp/ingestion, \`--ignore-missing-imports\`) clean
- full pytest: 434 passed, 41 skipped (DB-gated)
- per-surface manifest + annotation grouping confirmed against dev DB (obverse 427 / reverse 358, distinct surface images)
- frontend logic render-verified against the real source: selector renders, per-surface serve, per-surface overlay filtering + independent scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)