### PR TITLE
fix(#461): reload full user row on the session auth path

### DIFF
--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -3,15 +3,46 @@
 Injects `request.state.user` (dict with user fields) or `None` for
 unauthenticated requests. Routes that require auth use the `require_user`
 dependency in `api/dependencies.py`.
+
+Both auth paths reload the FULL users row by id (the API-key path always did;
+the session path was hardened to match in #461) so that any new users column is
+automatically present on `request.state.user` without editing a hand-listed
+SELECT — the #450 class of bug, where avatar_url/role/theme silently dropped
+from the session join until someone remembered to add them.
 """
+
+from typing import Optional
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
 from api.repositories.api_key_repo import ApiKeyRepository
 from api.repositories.session_repo import SessionRepository
+from api.repositories.user_repo import UserRepository
 from api.services.auth_service import hash_token
-from core.database import get_connection
+from core.database import DictConnection, get_connection
+
+
+def _load_session_user(conn: DictConnection, token_hash: str) -> Optional[dict]:
+    """Resolve a session token to the full users row, or None.
+
+    Resolves the session → user_id (no user columns selected), touches the
+    session's last-seen, then reloads the WHOLE users row via find_by_id so
+    every present and future column is carried — mirroring the API-key path.
+    Returns a dict with an injected ``session_id`` key, or None if the session
+    is missing / expired / its user no longer exists.
+    """
+    session_repo = SessionRepository(conn)
+    sess = session_repo.resolve_session(token_hash)
+    if not sess:
+        return None
+    user = UserRepository(conn).find_by_id(sess["user_id"])
+    if not user:
+        return None
+    session_repo.touch(sess["session_id"])
+    user = dict(user)
+    user["session_id"] = sess["session_id"]
+    return user
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
@@ -30,8 +61,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     key_row = api_key_repo.find_by_hash(key_hash)
                     if key_row:
                         api_key_repo.touch(key_row["id"])
-                        from api.repositories.user_repo import UserRepository
-
                         user_repo = UserRepository(conn)
                         user = user_repo.find_by_id(key_row["user_id"])
                         if user:
@@ -46,12 +75,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
             token_hash = hash_token(raw)
             try:
                 with get_connection() as conn:
-                    session_repo = SessionRepository(conn)
-                    row = session_repo.find_by_token_hash(token_hash)
-                    if row:
-                        session_repo.touch(row["session_id"])
-                        request.state.user = dict(row)
-                        request.state.session_id = row["session_id"]
+                    user = _load_session_user(conn, token_hash)
+                    if user:
+                        request.state.user = user
+                        request.state.session_id = user["session_id"]
             except Exception:
                 pass
 
@@ -62,12 +89,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 token_hash = hash_token(cookie_token)
                 try:
                     with get_connection() as conn:
-                        session_repo = SessionRepository(conn)
-                        row = session_repo.find_by_token_hash(token_hash)
-                        if row:
-                            session_repo.touch(row["session_id"])
-                            request.state.user = dict(row)
-                            request.state.session_id = row["session_id"]
+                        user = _load_session_user(conn, token_hash)
+                        if user:
+                            request.state.user = user
+                            request.state.session_id = user["session_id"]
                 except Exception:
                     pass
 

--- a/api/repositories/session_repo.py
+++ b/api/repositories/session_repo.py
@@ -36,7 +36,16 @@ class SessionRepository(BaseRepository):
         )
 
     def find_by_token_hash(self, token_hash: str) -> Optional[dict]:
-        """Return session joined with user, or None if not found / expired / revoked."""
+        """Return session joined with user, or None if not found / expired / revoked.
+
+        NOTE: this hand-lists the user columns and so silently drops any new
+        users column until someone adds it here (the #450 / #461 class of bug:
+        avatar_url/role/theme were all missing once). The auth middleware does
+        NOT rely on these user columns — it uses ``resolve_session`` below to get
+        the user_id, then reloads the full row via ``UserRepository.find_by_id``
+        so future columns are present automatically. This method is retained for
+        the repository-level tests and any caller that wants the joined shape.
+        """
         return self.fetch_one(
             """
             SELECT
@@ -53,6 +62,27 @@ class SessionRepository(BaseRepository):
                 u.theme
             FROM user_sessions s
             JOIN users u ON u.id = s.user_id
+            WHERE s.token_hash = %(token_hash)s
+              AND s.expires_at > now()
+            """,
+            {"token_hash": token_hash},
+        )
+
+    def resolve_session(self, token_hash: str) -> Optional[dict]:
+        """Resolve a session token to its session id + user id only.
+
+        Returns ``{"session_id": ..., "user_id": ...}`` for a live (unexpired)
+        session, or ``None``. Deliberately selects NO user columns — the caller
+        reloads the full users row via ``UserRepository.find_by_id`` so any
+        future users column is automatically reflected on the session auth path
+        without editing this query (the #461 fix; mirrors the API-key path).
+        """
+        return self.fetch_one(
+            """
+            SELECT
+                s.id      AS session_id,
+                s.user_id AS user_id
+            FROM user_sessions s
             WHERE s.token_hash = %(token_hash)s
               AND s.expires_at > now()
             """,

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -191,6 +191,103 @@ class TestSessionRepo:
         assert "role" in row
         assert "theme" in row
 
+    def test_resolve_session_returns_only_ids(self, test_user, session_repo, db_conn):
+        """#461: resolve_session returns just session_id + user_id (no user cols).
+
+        The middleware uses this to get the user_id, then reloads the full users
+        row via find_by_id — so the resolver intentionally carries no user
+        columns and can never drop one.
+        """
+        from datetime import datetime, timedelta, timezone
+        from api.services.auth_service import generate_session_token, hash_token
+
+        raw = generate_session_token()
+        token_hash = hash_token(raw)
+        expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+        session_repo.create_session(test_user["id"], token_hash, expires_at)
+        db_conn.commit()
+
+        sess = session_repo.resolve_session(token_hash)
+        assert sess is not None
+        assert str(sess["user_id"]) == str(test_user["id"])
+        assert "session_id" in sess
+
+    def test_resolve_session_expired_returns_none(
+        self, test_user, session_repo, db_conn
+    ):
+        from datetime import datetime, timedelta, timezone
+        from api.services.auth_service import generate_session_token, hash_token
+
+        raw = generate_session_token()
+        token_hash = hash_token(raw)
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        session_repo.create_session(test_user["id"], token_hash, past)
+        db_conn.commit()
+
+        assert session_repo.resolve_session(token_hash) is None
+
+    def test_session_path_carries_full_user_row(
+        self, test_user, user_repo, session_repo, db_conn
+    ):
+        """#461 regression: the session auth path must reflect the FULL users
+        row, so any *future* users column is present without editing a
+        hand-listed SELECT (the #450 class of bug, where avatar_url/role/theme
+        silently dropped from the join).
+
+        This reproduces exactly what the middleware does on the cookie/Bearer
+        path: resolve the session to a user_id, then reload the whole row via
+        find_by_id. We assert that EVERY column on the users table survives the
+        round-trip — including columns this test was never written to know
+        about — by diffing against the live table schema. Add a new users
+        column tomorrow and this test guarantees the session path carries it
+        with zero code changes to the auth path.
+        """
+        from datetime import datetime, timedelta, timezone
+        from api.services.auth_service import generate_session_token, hash_token
+        from api.middleware.auth import _load_session_user
+
+        raw = generate_session_token()
+        token_hash = hash_token(raw)
+        expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+        session_repo.create_session(test_user["id"], token_hash, expires_at)
+        db_conn.commit()
+
+        # What the middleware actually builds for request.state.user.
+        loaded = _load_session_user(db_conn, token_hash)
+        assert loaded is not None
+        assert str(loaded["id"]) == str(test_user["id"])
+        assert loaded["session_id"] is not None
+
+        # The columns that #450 added back by hand must still be present...
+        for col in (
+            "email",
+            "display_name",
+            "orcid_id",
+            "email_verified_at",
+            "avatar_url",
+            "role",
+            "theme",
+        ):
+            assert col in loaded, f"#450/#461 regression: '{col}' dropped"
+
+        # ...AND every other users column, discovered from the live schema, so a
+        # future column can never silently drop on the session path again.
+        with db_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'users'
+                """
+            )
+            all_user_columns = {r["column_name"] for r in cur.fetchall()}
+        missing = all_user_columns - set(loaded.keys())
+        assert not missing, (
+            f"#461 regression: session path dropped users columns {missing}. "
+            "The session auth path must reload the full users row (find_by_id) "
+            "so new columns appear automatically."
+        )
+
 
 class TestApiKeyRepo:
     def test_create_and_find(self, test_user, api_key_repo, db_conn):


### PR DESCRIPTION
## Problem (#461 — the #450 class)

The cookie/Bearer **session** auth path built `request.state.user` from a hand-listed `session → user` join (`SessionRepository.find_by_token_hash`). Any new `users` column silently returned absent until someone remembered to add it to that SELECT — which is exactly how `avatar_url` / `role` / `theme` dropped in #450, breaking avatars and admin role-gating on the cookie path. The **API-key** path was immune because it reloads the full row via `UserRepository.find_by_id`.

## Fix

Make the session path reload the full row too, mirroring the API-key path:

- `SessionRepository.resolve_session(token_hash)` → `{session_id, user_id}` — selects **no** user columns, so it can never drop one.
- New middleware helper `_load_session_user(conn, token_hash)`: resolve session → `user_id`, touch last-seen, then reload the **whole** `users` row via `find_by_id`. Both Bearer and cookie paths use it (the duplicated session block is gone). `session_id` is carried through to `request.state.session_id`, so logout/revoke still works.
- `find_by_token_hash` retained for repo-level tests / joined-shape callers, with a docstring noting it is no longer the auth read path.

One extra indexed primary-key lookup; no behavior regression — `email`, `display_name`, `orcid_id`, `email_verified_at`, `avatar_url`, `role`, `theme` all still present. Future `users` columns now appear on the session path automatically.

## Regression test

`tests/test_auth_routes.py::TestSessionRepo::test_session_path_carries_full_user_row` drives the **real** middleware helper and asserts the loaded user carries **every** `users` column, diffed against the live `information_schema` — so a future column can never silently drop again. Plus `resolve_session` id-only / expiry tests.

## Verified

Against Postgres 17 (throwaway DB at production `users` schema): the **old** hand-listed join dropped `affiliation, created_at, invite_code_id, name, password_hash`; the **new** full-row reload drops nothing. `ruff check .` + `ruff format --check .` + `mypy api/ app/ core/ mcp/ ingestion/` clean; all 14 auth-path tests pass. (DB-backed tests skip in CI, same as the existing session tests — production Postgres isn't reachable from Actions.)

Closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)