### PR TITLE
feat(#451): password login (in addition to magic-link) + longer sessions

### DIFF
--- a/api/repositories/user_repo.py
+++ b/api/repositories/user_repo.py
@@ -74,6 +74,19 @@ class UserRepository(BaseRepository):
                 {"url": avatar_url, "id": user_id},
             )
 
+    def set_password_hash(self, user_id: str, password_hash: str) -> None:
+        """Store (or replace) the PBKDF2 password hash for a user.
+
+        Additive auth: this lets a user who normally signs in via magic-link
+        or ORCID ALSO set a password. It never touches the magic-link/ORCID
+        auth-method rows, so those login paths keep working unchanged.
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "UPDATE users SET password_hash = %(hash)s WHERE id = %(id)s",
+                {"hash": password_hash, "id": user_id},
+            )
+
     def update_theme(self, user_id: str, theme: str) -> None:
         with self.conn.cursor() as cur:
             cur.execute(

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -39,6 +39,10 @@ class GenerateApiKeyRequest(BaseModel):
     tier: str = "free"
 
 
+class SetPasswordRequest(BaseModel):
+    password: str
+
+
 # ── ORCID OAuth ───────────────────────────────────────────────────────────────
 
 
@@ -189,6 +193,30 @@ def me(user: dict = Depends(require_user)):
         "role": user.get("role", "standard"),
         "theme": user.get("theme", "default"),
     }
+
+
+@router.post("/password")
+def set_password(
+    body: SetPasswordRequest,
+    user: dict = Depends(require_user),
+    conn=Depends(get_db),
+):
+    """Set or change the password for the currently logged-in user.
+
+    Additive auth (issue #451): the user is already authenticated via their
+    session (magic-link / ORCID / existing password). This stores a PBKDF2
+    hash so they can ALSO sign in with email + password going forward. It does
+    not touch magic-link or ORCID, which keep working exactly as before.
+    """
+    password = body.password.strip()
+    if len(password) < 8:
+        raise HTTPException(
+            status_code=400, detail="Password must be at least 8 characters"
+        )
+    password_hash = auth_service.hash_password(password)
+    UserRepository(conn).set_password_hash(user["id"], password_hash)
+    conn.commit()
+    return {"status": "ok"}
 
 
 @router.post("/avatar")

--- a/app/routes/account.py
+++ b/app/routes/account.py
@@ -65,6 +65,42 @@ def avatar_proxy(file: UploadFile, request: Request):
         return Response(status_code=500)
 
 
+class _PasswordBody(BaseModel):
+    password: str
+
+
+@router.post("/_me/password", status_code=204)
+def set_password_proxy(body: _PasswordBody, request: Request):
+    """Same-origin proxy so account-page JS can set a password (issue #451).
+
+    The session_token cookie is scoped to the app host, so the browser cannot
+    call the API directly; this forwards it server-side as a Bearer header.
+    """
+    token = request.cookies.get("session_token")
+    if not token:
+        return Response(status_code=401)
+    from app.api_client import AuthRequiredError
+
+    try:
+        request.app.state.api.post(
+            "/auth/password",
+            json={"password": body.password},
+            token=token,
+        )
+    except AuthRequiredError:
+        return Response(status_code=401)
+    except httpx.HTTPStatusError as exc:
+        # Surface the API's validation message (e.g. "Password must be at
+        # least 8 characters") to the browser.
+        detail = "Could not set password."
+        try:
+            detail = exc.response.json().get("detail", detail)
+        except Exception:
+            pass
+        return JSONResponse({"detail": detail}, status_code=exc.response.status_code)
+    return Response(status_code=204)
+
+
 _VALID_THEMES = {"default", "lapis-clay", "scholars-studio", "instrument-panel"}
 
 

--- a/app/static/css/pages/account.css
+++ b/app/static/css/pages/account.css
@@ -277,6 +277,32 @@
     background: linear-gradient(135deg, #111418 50%, #c9920a 50%);
 }
 
+/* Password */
+.account-password-form {
+    max-width: 28rem;
+}
+
+.account-password-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-4);
+    flex-wrap: wrap;
+}
+
+.account-password-status {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
+.account-password-status.is-error {
+    color: var(--color-error);
+}
+
+.account-password-status.is-success {
+    color: var(--color-success);
+}
+
 /* Misc */
 .text-muted {
     color: var(--color-text-muted);

--- a/app/templates/account/index.html
+++ b/app/templates/account/index.html
@@ -112,6 +112,26 @@
         </div>
     </section>
 
+    {# Password #}
+    <section class="account-section">
+        <h2 class="account-section-title">Password</h2>
+        <p class="account-section-description">Set a password so you can sign in with your email and password, in addition to the email magic link. Setting a password does not disable magic-link sign-in.</p>
+        <form id="password-form" class="account-password-form" autocomplete="off">
+            <div class="form-group">
+                <label class="form-label" for="new-password">New password</label>
+                <input type="password" id="new-password" name="password" class="form-input" minlength="8" autocomplete="new-password" placeholder="At least 8 characters" required>
+            </div>
+            <div class="form-group">
+                <label class="form-label" for="confirm-password">Confirm password</label>
+                <input type="password" id="confirm-password" name="confirm" class="form-input" minlength="8" autocomplete="new-password" placeholder="Re-enter password" required>
+            </div>
+            <div class="account-password-actions">
+                <button type="submit" class="btn btn--sm btn--primary">Save password</button>
+                <span id="password-status" class="account-password-status" role="status" aria-live="polite"></span>
+            </div>
+        </form>
+    </section>
+
     {# Collections quick link #}
     <section class="account-section">
         <h2 class="account-section-title">My Collections</h2>
@@ -205,6 +225,49 @@ document.getElementById('avatar-file').addEventListener('change', async (e) => {
         if (hav) hav.innerHTML = `<img src="${data.avatar_url}" alt="" class="header-avatar__img">`;
     } catch {
         alert('Upload failed. Please try again.');
+    }
+});
+
+// Set / change password — posts to the same-origin proxy (/_me/password)
+// which forwards the session cookie to the API as a Bearer token.
+document.getElementById('password-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const pw = document.getElementById('new-password').value;
+    const confirm = document.getElementById('confirm-password').value;
+    const status = document.getElementById('password-status');
+    status.classList.remove('is-error', 'is-success');
+
+    if (pw.length < 8) {
+        status.textContent = 'Password must be at least 8 characters.';
+        status.classList.add('is-error');
+        return;
+    }
+    if (pw !== confirm) {
+        status.textContent = 'Passwords do not match.';
+        status.classList.add('is-error');
+        return;
+    }
+
+    status.textContent = 'Saving…';
+    try {
+        const res = await fetch('/_me/password', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: pw }),
+        });
+        if (res.ok) {
+            status.textContent = 'Password saved. You can now sign in with email and password.';
+            status.classList.add('is-success');
+            e.target.reset();
+        } else {
+            let detail = 'Could not save password.';
+            try { detail = (await res.json()).detail || detail; } catch {}
+            status.textContent = detail;
+            status.classList.add('is-error');
+        }
+    } catch {
+        status.textContent = 'Could not save password. Please try again.';
+        status.classList.add('is-error');
     }
 });
 

--- a/core/config.py
+++ b/core/config.py
@@ -114,7 +114,11 @@ class Settings(BaseSettings):
 
     # Session
     session_secret_key: str = "dev-insecure-key"
-    session_lifetime_days: int = 30
+    # Sessions last 60 days so users (esp. returning scholars) stay logged in
+    # across visits without re-authenticating constantly. This single value
+    # drives BOTH the DB session row expiry (_create_session_response) and the
+    # session_token cookie max-age (_set_session_cookie), keeping them consistent.
+    session_lifetime_days: int = 60
 
     deploy_host: Optional[str] = None
     deploy_user: str = "deploy"

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -577,3 +577,81 @@ class TestGenerateInviteScript:
                 assert ambiguous not in code, (
                     f"Ambiguous char '{ambiguous}' found in {code}"
                 )
+
+
+# ── Issue #451: additive password auth + longer session ──────────────────────
+
+
+class TestIssue451PasswordAndSession:
+    """Issue #451: a user can ADD a password without breaking magic-link.
+
+    These tests assert the behaviour the new code guarantees:
+      - set_password_hash stores a verifiable PBKDF2 hash on the user row
+      - email + password verifies after the user sets one
+      - a wrong password is rejected
+      - the magic-link path still mints a session with no password set
+      - the session lifetime default is the new, longer value (60 days)
+    """
+
+    def test_set_password_hash_then_verify(self, user_repo, db_conn):
+        """A magic-link user can set a password and it verifies."""
+        from api.services.auth_service import hash_password, verify_password
+
+        user = user_repo.create_user(email="set-pw-451@glintstone.example")
+        user_repo.link_auth_method(user["id"], "magic_link", user["email"])
+        db_conn.commit()
+
+        user_repo.set_password_hash(user["id"], hash_password("barley-and-emmer-7"))
+        db_conn.commit()
+
+        row = user_repo.find_by_email("set-pw-451@glintstone.example")
+        assert row["password_hash"]
+        assert verify_password("barley-and-emmer-7", row["password_hash"]) is True
+
+    def test_wrong_password_rejected(self, user_repo, db_conn):
+        from api.services.auth_service import hash_password, verify_password
+
+        user = user_repo.create_user(email="wrong-pw-451@glintstone.example")
+        user_repo.set_password_hash(user["id"], hash_password("correct-horse"))
+        db_conn.commit()
+
+        row = user_repo.find_by_email("wrong-pw-451@glintstone.example")
+        assert verify_password("not-the-password", row["password_hash"]) is False
+
+    def test_magic_link_user_has_no_password_by_default(self, user_repo, db_conn):
+        """A user who only ever used magic-link has no password_hash — the
+        password is purely additive, never required."""
+        user = user_repo.create_user(email="ml-only-451@glintstone.example")
+        user_repo.link_auth_method(user["id"], "magic_link", user["email"])
+        db_conn.commit()
+        row = user_repo.find_by_email("ml-only-451@glintstone.example")
+        assert row["password_hash"] is None
+
+    def test_magic_link_still_mints_session(self, user_repo, session_repo, db_conn):
+        """The magic-link login path (create user → mint session) is unchanged
+        and works for a user with no password set."""
+        from datetime import datetime, timedelta, timezone
+
+        from api.services.auth_service import generate_session_token, hash_token
+
+        user = user_repo.create_user(email="ml-session-451@glintstone.example")
+        user_repo.link_auth_method(user["id"], "magic_link", user["email"])
+        db_conn.commit()
+
+        raw = generate_session_token()
+        token_hash = hash_token(raw)
+        expires_at = datetime.now(timezone.utc) + timedelta(days=60)
+        session_repo.create_session(user["id"], token_hash, expires_at)
+        db_conn.commit()
+
+        found = session_repo.find_by_token_hash(token_hash)
+        assert found is not None
+        assert found["email"] == "ml-session-451@glintstone.example"
+
+    def test_session_lifetime_is_longer(self):
+        """Session lifetime default was bumped to 60 days (issue #451 part 2).
+        This value drives BOTH the DB expiry and the cookie max-age."""
+        from core.config import Settings
+
+        assert Settings().session_lifetime_days == 60
+        assert Settings().session_lifetime_days >= 30


### PR DESCRIPTION
Closes #451.

Eric asked for a password he can use **in addition to** the email magic link, plus staying logged in longer. Both are additive and the existing magic-link / ORCID login is fully untouched.

## Part 1 — password in addition to magic-link
- **API** `POST /auth/password` — a logged-in user sets or changes a password. Hashes with the existing `auth_service.hash_password` (PBKDF2-SHA256, random salt, constant-time `verify_password`). Stored on the existing `users.password_hash` column (migration 044) via new `UserRepository.set_password_hash`. **No schema change, no new GRANT.**
- Email+password login (`POST /auth/email/login`) already existed — unchanged.
- **App** same-origin proxy `POST /_me/password` (forwards the session cookie as a Bearer token, mirroring the avatar/preferences proxies) + a new "Password" section in account settings (set + confirm, min 8 chars, token-driven CSS, no raw hex).
- A user who never sets a password keeps signing in exactly as before.

## Part 2 — longer session
- `session_lifetime_days` **30 → 60**. This one setting drives **both** the DB session-row expiry and the `session_token` cookie max-age, so they stay consistent.

## No-lockout safety
- Magic-link path (`/auth/magic-link/verify`, `/auth/verify`, `_create_session_response`) and ORCID path are byte-for-byte unchanged. Password is purely additive.

## Tests (tests/test_auth_routes.py)
- set-password + verify round-trip
- wrong password rejected
- magic-link user has no password by default
- magic-link still mints a session
- session TTL is the new 60-day value

Local gate: ruff clean, ruff format clean, mypy clean (`api app core mcp ingestion --ignore-missing-imports`), non-DB tests pass. DB-backed tests run in CI (no local Postgres here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)