### PR TITLE
feat(#17): Scholar Identity keystone — claim, ORCID auto-match, bio overlay, admin review

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.middleware.auth import AuthMiddleware
 from api.routes import (
+    admin,
     agent,
     artifacts,
     auth,
@@ -134,3 +135,4 @@ app.include_router(agent.composites_agent_router)
 app.include_router(agent.corrections_router)
 app.include_router(auth.router)
 app.include_router(users.router)
+app.include_router(admin.router)

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,0 +1,163 @@
+"""Admin API routes — scholar-claim review queue + verification (#17).
+
+These are the admin-gated half of the Scholar Identity feature. The web app's
+admin pages proxy to these over HTTP (two-tier rule). Every route requires the
+``admin`` role via ``require_admin`` — a standard user hitting them gets 403.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from api.dependencies import require_admin
+from core.database import get_db
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class VerifyClaimRequest(BaseModel):
+    action: str  # 'approve' | 'reject'
+    review_note: str | None = None
+
+
+@router.get("/scholar-claims")
+def list_scholar_claims(
+    status: str = "pending",
+    admin: dict = Depends(require_admin),
+    conn=Depends(get_db),
+):
+    """The review queue feed. Default ``status=pending`` (oldest first, so the
+    longest-waiting claimant is reviewed first). ``approved`` / ``rejected``
+    filters show the audit trail (who acted, when). Each row carries the user
+    (email/name/orcid) and the scholar (name/institution/pub count) so the
+    reviewer has full context in one screen.
+    """
+    if status not in ("pending", "approved", "rejected"):
+        raise HTTPException(status_code=400, detail="Invalid status filter")
+
+    order = (
+        "c.claimed_at ASC" if status == "pending" else "c.verified_at DESC NULLS LAST"
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT c.id, c.scholar_id, c.status, c.verification_method,
+                   c.claim_note, c.claimed_at, c.verified_at, c.review_note,
+                   u.id AS user_id, u.email AS user_email,
+                   u.display_name AS user_display_name, u.orcid_id AS user_orcid,
+                   s.name AS scholar_name, s.institution AS scholar_institution,
+                   (SELECT COUNT(*) FROM publication_authors pa
+                     WHERE pa.scholar_id = s.id) AS scholar_publication_count,
+                   v.display_name AS verified_by_name
+            FROM scholar_claims c
+            JOIN users u    ON u.id = c.user_id
+            JOIN scholars s ON s.id = c.scholar_id
+            LEFT JOIN users v ON v.id = c.verified_by
+            WHERE c.status = %s
+            ORDER BY {order}
+            """,
+            (status,),
+        )
+        rows = cur.fetchall()
+
+        # Counts for the filter pills (always all three, regardless of filter).
+        cur.execute("SELECT status, COUNT(*) AS n FROM scholar_claims GROUP BY status")
+        counts = {r["status"]: int(r["n"]) for r in cur.fetchall()}
+
+    return {
+        "items": [dict(r) for r in rows],
+        "counts": {
+            "pending": counts.get("pending", 0),
+            "approved": counts.get("approved", 0),
+            "rejected": counts.get("rejected", 0),
+        },
+        "status": status,
+    }
+
+
+@router.post("/scholar-claims/{claim_id}/verify")
+def verify_scholar_claim(
+    claim_id: str,
+    body: VerifyClaimRequest,
+    admin: dict = Depends(require_admin),
+    conn=Depends(get_db),
+):
+    """Approve or reject a pending claim.
+
+    Approve → status='approved', stamps verified_at/verified_by, and creates the
+    empty ``scholar_overrides`` shell so the claimant's bio editor is immediately
+    available. The partial unique index enforces one approved claim per scholar:
+    a second approval on an already-claimed scholar raises 409 rather than
+    silently double-claiming.
+
+    Reject → status='rejected' with a REQUIRED review_note (shown back to the
+    claimant on their /account page). Two-step in the UI; required here so a
+    reject never reaches the user with no explanation.
+    """
+    action = body.action.strip().lower()
+    if action not in ("approve", "reject"):
+        raise HTTPException(status_code=400, detail="action must be approve or reject")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, scholar_id, user_id, status FROM scholar_claims WHERE id = %s",
+            (claim_id,),
+        )
+        claim = cur.fetchone()
+        if not claim:
+            raise HTTPException(status_code=404, detail="Claim not found")
+        if claim["status"] != "pending":
+            raise HTTPException(
+                status_code=409, detail="This claim has already been reviewed."
+            )
+
+        if action == "reject":
+            note = (body.review_note or "").strip()
+            if not note:
+                raise HTTPException(
+                    status_code=400,
+                    detail="A reason is required when rejecting a claim.",
+                )
+            cur.execute(
+                """
+                UPDATE scholar_claims
+                   SET status = 'rejected', review_note = %s,
+                       verified_at = now(), verified_by = %s
+                 WHERE id = %s
+                """,
+                (note, admin["id"], claim_id),
+            )
+            conn.commit()
+            return {"status": "rejected"}
+
+        # Approve — guard against an existing approved claim for this scholar so
+        # the partial unique index never surprises us with a rollback-trap error.
+        cur.execute(
+            "SELECT 1 FROM scholar_claims "
+            "WHERE scholar_id = %s AND status = 'approved'",
+            (claim["scholar_id"],),
+        )
+        if cur.fetchone():
+            raise HTTPException(
+                status_code=409,
+                detail="Another claim on this scholar is already approved.",
+            )
+        cur.execute(
+            """
+            UPDATE scholar_claims
+               SET status = 'approved', verified_at = now(), verified_by = %s,
+                   review_note = %s
+             WHERE id = %s
+            """,
+            (admin["id"], (body.review_note or "").strip() or None, claim_id),
+        )
+        # Create the empty overlay shell. ON CONFLICT, not try/except (rollback trap).
+        cur.execute(
+            """
+            INSERT INTO scholar_overrides (scholar_id, edited_by_user_id)
+            VALUES (%s, %s)
+            ON CONFLICT (scholar_id) DO NOTHING
+            """,
+            (claim["scholar_id"], claim["user_id"]),
+        )
+    conn.commit()
+    return {"status": "approved"}

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -355,6 +355,180 @@ def email_register(body: EmailRegisterRequest, request: Request, conn=Depends(ge
     return _create_session_response(user, conn, request, settings)
 
 
+# ── Scholar identity — claims (#17) ───────────────────────────────────────────
+
+
+class ScholarClaimRequest(BaseModel):
+    scholar_id: int
+    claim_note: str | None = None
+
+
+@router.get("/orcid-match")
+def orcid_match(user: dict = Depends(require_user), conn=Depends(get_db)):
+    """The auto-match probe the post-login prompt calls.
+
+    Returns the UNCLAIMED scholar record whose ``orcid`` equals the logged-in
+    user's ``orcid_id``, or ``null``. The join is ``users.orcid_id =
+    scholars.orcid``; both columns are unique. Cheap; drives the "We found your
+    record" banner. We exclude scholars that already carry an approved claim so
+    the banner never offers a record the user can't actually take.
+    """
+    orcid = user.get("orcid_id")
+    if not orcid:
+        return {"match": None}
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT s.id, s.name, s.institution,
+                   (SELECT COUNT(*) FROM publication_authors pa
+                     WHERE pa.scholar_id = s.id) AS publication_count
+            FROM scholars s
+            WHERE s.orcid = %s
+              AND NOT EXISTS (
+                  SELECT 1 FROM scholar_claims c
+                  WHERE c.scholar_id = s.id AND c.status = 'approved'
+              )
+            LIMIT 1
+            """,
+            (orcid,),
+        )
+        row = cur.fetchone()
+    return {"match": dict(row) if row else None}
+
+
+@router.post("/scholar-claims", status_code=201)
+def create_scholar_claim(
+    body: ScholarClaimRequest,
+    user: dict = Depends(require_user),
+    conn=Depends(get_db),
+):
+    """File a claim on a scholar record.
+
+    If the user's ``orcid_id`` matches ``scholars.orcid`` → the claim is created
+    ``approved`` / ``orcid_match`` instantly (ORCID is a verified global identity;
+    no admin step adds safety). Otherwise it is ``pending`` / ``manual_review``
+    and goes to the admin queue. Rejects with 409 if the scholar already has an
+    approved claim (one person per scholar) or if this user already has a pending
+    claim on the same record.
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT id, orcid FROM scholars WHERE id = %s", (body.scholar_id,))
+        scholar = cur.fetchone()
+        if not scholar:
+            raise HTTPException(status_code=404, detail="Scholar not found")
+
+        # Already claimed by someone (approved) → 409, offer the dispute path.
+        cur.execute(
+            "SELECT 1 FROM scholar_claims "
+            "WHERE scholar_id = %s AND status = 'approved'",
+            (body.scholar_id,),
+        )
+        if cur.fetchone():
+            raise HTTPException(
+                status_code=409, detail="This scholar record has already been claimed."
+            )
+
+        # This user already has a pending claim on this scholar → 409 (no spam).
+        cur.execute(
+            "SELECT 1 FROM scholar_claims "
+            "WHERE scholar_id = %s AND user_id = %s AND status = 'pending'",
+            (body.scholar_id, user["id"]),
+        )
+        if cur.fetchone():
+            raise HTTPException(
+                status_code=409,
+                detail="You already have a pending claim on this record.",
+            )
+
+        # ORCID auto-match: the user authenticated against this ORCID at login.
+        user_orcid = user.get("orcid_id")
+        is_orcid_match = bool(
+            user_orcid and scholar["orcid"] and scholar["orcid"] == user_orcid
+        )
+        if is_orcid_match:
+            cur.execute(
+                """
+                INSERT INTO scholar_claims
+                    (user_id, scholar_id, status, verification_method,
+                     claim_note, verified_at)
+                VALUES (%s, %s, 'approved', 'orcid_match', %s, now())
+                RETURNING *
+                """,
+                (user["id"], body.scholar_id, body.claim_note),
+            )
+            claim = cur.fetchone()
+            # Create the empty overlay shell so the bio editor is immediately
+            # available. ON CONFLICT (not try/except) per the psycopg rollback trap.
+            cur.execute(
+                """
+                INSERT INTO scholar_overrides (scholar_id, edited_by_user_id)
+                VALUES (%s, %s)
+                ON CONFLICT (scholar_id) DO NOTHING
+                """,
+                (body.scholar_id, user["id"]),
+            )
+        else:
+            cur.execute(
+                """
+                INSERT INTO scholar_claims
+                    (user_id, scholar_id, status, verification_method, claim_note)
+                VALUES (%s, %s, 'pending', 'manual_review', %s)
+                RETURNING *
+                """,
+                (user["id"], body.scholar_id, body.claim_note),
+            )
+            claim = cur.fetchone()
+    conn.commit()
+    return dict(claim)
+
+
+@router.get("/scholar-claims/me")
+def my_scholar_claims(user: dict = Depends(require_user), conn=Depends(get_db)):
+    """The signed-in user's claims, newest first, with the scholar's name.
+
+    Drives the /account "Scholar identity" status surface and the post-login
+    prompt's dismissal logic.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT c.id, c.scholar_id, c.status, c.verification_method,
+                   c.claim_note, c.claimed_at, c.verified_at, c.review_note,
+                   s.name AS scholar_name, s.institution AS scholar_institution
+            FROM scholar_claims c
+            JOIN scholars s ON s.id = c.scholar_id
+            WHERE c.user_id = %s
+            ORDER BY c.claimed_at DESC
+            """,
+            (user["id"],),
+        )
+        rows = cur.fetchall()
+    return {"items": [dict(r) for r in rows]}
+
+
+@router.post("/scholar-claims/{claim_id}/withdraw", status_code=204)
+def withdraw_scholar_claim(
+    claim_id: str, user: dict = Depends(require_user), conn=Depends(get_db)
+):
+    """Withdraw a pending claim. Sets status='rejected' with a withdrawn note
+    rather than hard-deleting, keeping a clean audit row (spec open-question #1
+    default). Only the owner can withdraw, and only while pending.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE scholar_claims
+               SET status = 'rejected', review_note = 'Withdrawn by user'
+             WHERE id = %s AND user_id = %s AND status = 'pending'
+            """,
+            (claim_id, user["id"]),
+        )
+        updated = cur.rowcount
+    conn.commit()
+    if not updated:
+        raise HTTPException(status_code=404, detail="No pending claim to withdraw")
+
+
 # ── Internal helper ───────────────────────────────────────────────────────────
 
 

--- a/api/routes/scholars.py
+++ b/api/routes/scholars.py
@@ -6,11 +6,15 @@ this module exists so the web layer can render a Browse-Scholars listing
 without making search a precondition for navigation.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 
+from api.dependencies import require_user
 from core.database import get_db
 
 router = APIRouter(prefix="/scholars", tags=["scholars"])
+
+BIO_MAX_LEN = 1500
 
 
 def _scholar_filters(
@@ -224,19 +228,178 @@ def get_scholar_facets(
 
 @router.get("/{scholar_id}")
 def get_scholar(scholar_id: int, conn=Depends(get_db)):
+    """Public scholar read model (#17 extends it with the claim overlay).
+
+    When a verified claim + bio override exist, the overlay wins per field via
+    COALESCE(override, ingested) — so the claimant's edits show without ever
+    mutating the ORACC-ingested ``scholars`` row. The ``claim`` block tells the
+    page whether to render the "Claimed · verified" badge, the bio, and the
+    "edited by this scholar" markers. A bio/avatar surfaces ONLY when an APPROVED
+    claim exists; a pending claim shows nothing public (spec decision #4).
+    ``bio_overridden`` etc. let the template mark exactly which fields the
+    scholar edited.
+    """
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT id, name, normalized_name, orcid, institution,
-                   expertise_periods, expertise_languages, active_since, author_type
-            FROM scholars
-            WHERE id = %s
+            SELECT s.id, s.name, s.normalized_name, s.orcid, s.active_since,
+                   s.author_type,
+                   COALESCE(o.institution, s.institution)               AS institution,
+                   COALESCE(o.expertise_periods, s.expertise_periods)   AS expertise_periods,
+                   COALESCE(o.expertise_languages, s.expertise_languages) AS expertise_languages,
+                   s.institution         AS ingested_institution,
+                   s.expertise_periods   AS ingested_expertise_periods,
+                   s.expertise_languages AS ingested_expertise_languages,
+                   o.bio                 AS bio,
+                   o.homepage_url        AS homepage_url,
+                   (o.institution IS NOT NULL)         AS institution_overridden,
+                   (o.expertise_periods IS NOT NULL)   AS expertise_periods_overridden,
+                   (o.expertise_languages IS NOT NULL) AS expertise_languages_overridden,
+                   c.id          AS claim_id,
+                   c.status      AS claim_status,
+                   c.verified_at AS claim_verified_at,
+                   c.verification_method AS claim_method,
+                   u.display_name AS claimant_display_name,
+                   u.avatar_url   AS claimant_avatar_url
+            FROM scholars s
+            LEFT JOIN scholar_claims c
+                   ON c.scholar_id = s.id AND c.status = 'approved'
+            LEFT JOIN scholar_overrides o ON o.scholar_id = s.id
+            LEFT JOIN users u ON u.id = c.user_id
+            WHERE s.id = %s
             """,
             (scholar_id,),
         )
         row = cur.fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="Scholar not found")
+
+    r = dict(row)
+    verified = r.get("claim_status") == "approved"
+    # Public surfaces (bio/avatar/badge) appear ONLY for a verified claim.
+    claim = {
+        "claimed": verified,
+        "verified": verified,
+        "verified_at": r.pop("claim_verified_at", None) if verified else None,
+        "method": r.pop("claim_method", None) if verified else None,
+        "claimant_display_name": r.get("claimant_display_name") if verified else None,
+    }
+    bio = r.get("bio") if verified else None
+    homepage_url = r.get("homepage_url") if verified else None
+    avatar_url = r.get("claimant_avatar_url") if verified else None
+
+    return {
+        "id": r["id"],
+        "name": r["name"],
+        "normalized_name": r["normalized_name"],
+        "orcid": r["orcid"],
+        "active_since": r["active_since"],
+        "author_type": r["author_type"],
+        "institution": r["institution"],
+        "expertise_periods": r["expertise_periods"],
+        "expertise_languages": r["expertise_languages"],
+        # Per-field override flags (only meaningful when verified) so the page can
+        # mark "· edited by this scholar" exactly where the scholar changed a value.
+        "institution_overridden": bool(r["institution_overridden"]) and verified,
+        "expertise_periods_overridden": bool(r["expertise_periods_overridden"])
+        and verified,
+        "expertise_languages_overridden": bool(r["expertise_languages_overridden"])
+        and verified,
+        "bio": bio,
+        "homepage_url": homepage_url,
+        "avatar_url": avatar_url,
+        "claim": claim,
+    }
+
+
+class BioUpdateRequest(BaseModel):
+    bio: str | None = None
+    institution: str | None = None
+    homepage_url: str | None = None
+    expertise_periods: str | None = None
+    expertise_languages: str | None = None
+
+
+def _norm(value: str | None) -> str | None:
+    """Empty/whitespace-only string → NULL so the field reverts to the ingested
+    value via COALESCE rather than overriding it with a blank."""
+    if value is None:
+        return None
+    v = value.strip()
+    return v or None
+
+
+@router.put("/{scholar_id}/bio")
+def update_scholar_bio(
+    scholar_id: int,
+    body: BioUpdateRequest,
+    request: Request,
+    user: dict = Depends(require_user),
+    conn=Depends(get_db),
+):
+    """Upsert the bio overlay for a scholar the caller has an APPROVED claim on.
+
+    The load-bearing authorization check: the caller must hold the approved
+    claim for this scholar_id, else 403 — a user cannot edit a profile they
+    haven't claimed. Validates bio length and homepage URL shape. Blank fields
+    clear the override (revert to the ingested value). Writes to
+    ``scholar_overrides`` only; ``scholars`` is never mutated.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM scholar_claims "
+            "WHERE scholar_id = %s AND user_id = %s AND status = 'approved'",
+            (scholar_id, user["id"]),
+        )
+        if not cur.fetchone():
+            raise HTTPException(
+                status_code=403,
+                detail="You can only edit a scholar profile you have claimed.",
+            )
+
+        bio = _norm(body.bio)
+        if bio and len(bio) > BIO_MAX_LEN:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Biography must be {BIO_MAX_LEN} characters or fewer.",
+            )
+        homepage = _norm(body.homepage_url)
+        if homepage and not (
+            homepage.startswith("http://") or homepage.startswith("https://")
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Homepage must start with http:// or https://",
+            )
+
+        cur.execute(
+            """
+            INSERT INTO scholar_overrides
+                (scholar_id, edited_by_user_id, bio, institution, homepage_url,
+                 expertise_periods, expertise_languages, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, now())
+            ON CONFLICT (scholar_id) DO UPDATE SET
+                edited_by_user_id   = EXCLUDED.edited_by_user_id,
+                bio                 = EXCLUDED.bio,
+                institution         = EXCLUDED.institution,
+                homepage_url        = EXCLUDED.homepage_url,
+                expertise_periods   = EXCLUDED.expertise_periods,
+                expertise_languages = EXCLUDED.expertise_languages,
+                updated_at          = now()
+            RETURNING *
+            """,
+            (
+                scholar_id,
+                user["id"],
+                bio,
+                _norm(body.institution),
+                homepage,
+                _norm(body.expertise_periods),
+                _norm(body.expertise_languages),
+            ),
+        )
+        row = cur.fetchone()
+    conn.commit()
     return dict(row)
 
 

--- a/app/api_client.py
+++ b/app/api_client.py
@@ -254,6 +254,33 @@ class GlintstoneAPI:
         except Exception:
             return {}
 
+    # ── Scholar identity / claims (#17) ──────────────────────────────────────
+
+    def get_orcid_match(self, token: str) -> dict:
+        """The post-login auto-match probe. {"match": {...}|None}. Degrades to
+        no-match on any error so a probe failure simply shows no prompt."""
+        try:
+            result = self._t.get("/auth/orcid-match", token=token)
+            return result if isinstance(result, dict) else {"match": None}
+        except Exception:
+            return {"match": None}
+
+    def get_my_scholar_claims(self, token: str) -> list:
+        """The signed-in user's claims (for /account + prompt dismissal)."""
+        try:
+            result = self._t.get("/auth/scholar-claims/me", token=token)
+            return result.get("items", []) if isinstance(result, dict) else []
+        except Exception:
+            return []
+
+    def list_admin_scholar_claims(self, status: str, token: str) -> dict:
+        """The admin review queue feed. Raises on error (admin routes propagate
+        so the page can surface a real failure rather than a silent empty queue)."""
+        result = self._t.get(
+            "/admin/scholar-claims", params={"status": status}, token=token
+        )
+        return result if isinstance(result, dict) else {"items": [], "counts": {}}
+
     def get_scholar_activity(self, scholar_id: int) -> dict:
         """Compact activity profile for a scholar (#157) — period histogram +
         role breakdown. Degrades to an explicit-empty envelope on any failure so

--- a/app/routes/account.py
+++ b/app/routes/account.py
@@ -134,6 +134,139 @@ def preferences_proxy(body: _PreferencesBody, request: Request, response: Respon
         pass  # DB sync is best-effort; cookie already guarantees the theme persists
 
 
+# ── Scholar identity proxies (#17) ────────────────────────────────────────────
+# Same-origin proxies so claim/bio/admin JS can reach the API with the session
+# cookie forwarded as a Bearer token (the cookie is scoped to the app host).
+
+
+class _ClaimBody(BaseModel):
+    scholar_id: int
+    claim_note: str | None = None
+
+
+@router.post("/_me/scholar-claims", status_code=201)
+def claim_scholar_proxy(body: _ClaimBody, request: Request):
+    token = request.cookies.get("session_token")
+    if not token:
+        return Response(status_code=401)
+    from app.api_client import AuthRequiredError
+
+    try:
+        result = request.app.state.api.post(
+            "/auth/scholar-claims",
+            json={"scholar_id": body.scholar_id, "claim_note": body.claim_note},
+            token=token,
+        )
+    except AuthRequiredError:
+        return Response(status_code=401)
+    except httpx.HTTPStatusError as exc:
+        detail = "Could not file the claim."
+        try:
+            detail = exc.response.json().get("detail", detail)
+        except Exception:
+            pass
+        return JSONResponse({"detail": detail}, status_code=exc.response.status_code)
+    return JSONResponse(result, status_code=201)
+
+
+@router.post("/_me/scholar-claims/{claim_id}/withdraw", status_code=204)
+def withdraw_claim_proxy(claim_id: str, request: Request):
+    token = request.cookies.get("session_token")
+    if not token:
+        return Response(status_code=401)
+    try:
+        request.app.state.api.post(
+            f"/auth/scholar-claims/{claim_id}/withdraw", token=token
+        )
+    except httpx.HTTPStatusError as exc:
+        return Response(status_code=exc.response.status_code)
+    return Response(status_code=204)
+
+
+class _BioBody(BaseModel):
+    bio: str | None = None
+    institution: str | None = None
+    homepage_url: str | None = None
+    expertise_periods: str | None = None
+    expertise_languages: str | None = None
+
+
+@router.put("/_me/scholars/{scholar_id}/bio")
+def bio_proxy(scholar_id: int, body: _BioBody, request: Request):
+    token = request.cookies.get("session_token")
+    if not token:
+        return Response(status_code=401)
+    from app.api_client import AuthRequiredError
+
+    try:
+        result = request.app.state.api.put(
+            f"/scholars/{scholar_id}/bio",
+            json=body.model_dump(),
+            token=token,
+        )
+    except AuthRequiredError:
+        return Response(status_code=401)
+    except httpx.HTTPStatusError as exc:
+        detail = "Could not save the profile."
+        try:
+            detail = exc.response.json().get("detail", detail)
+        except Exception:
+            pass
+        return JSONResponse({"detail": detail}, status_code=exc.response.status_code)
+    return JSONResponse(result)
+
+
+class _VerifyBody(BaseModel):
+    action: str
+    review_note: str | None = None
+
+
+@router.post("/_me/admin/scholar-claims/{claim_id}/verify")
+def verify_claim_proxy(claim_id: str, body: _VerifyBody, request: Request):
+    token = request.cookies.get("session_token")
+    if not token:
+        return Response(status_code=401)
+    from app.api_client import AuthRequiredError
+
+    try:
+        result = request.app.state.api.post(
+            f"/admin/scholar-claims/{claim_id}/verify",
+            json={"action": body.action, "review_note": body.review_note},
+            token=token,
+        )
+    except AuthRequiredError:
+        return Response(status_code=401)
+    except httpx.HTTPStatusError as exc:
+        detail = "Could not record the decision."
+        try:
+            detail = exc.response.json().get("detail", detail)
+        except Exception:
+            pass
+        return JSONResponse({"detail": detail}, status_code=exc.response.status_code)
+    return JSONResponse(result)
+
+
+@router.get("/_me/orcid-match")
+def orcid_match_proxy(request: Request):
+    """Drives the post-login claim prompt. Returns the matched unclaimed scholar
+    (or {match:null}). Degrades to no-match on any error so a probe failure
+    simply shows no banner (spec: degrade quietly)."""
+    token = request.cookies.get("session_token")
+    if not token:
+        return JSONResponse({"match": None})
+    return JSONResponse(request.app.state.api.get_orcid_match(token))
+
+
+@router.get("/_me/scholar-claims")
+def my_claims_proxy(request: Request):
+    """The signed-in user's claims, for the post-login banner's manual-nudge
+    branch (only nudge users who have no claim yet)."""
+    token = request.cookies.get("session_token")
+    if not token:
+        return JSONResponse({"items": []})
+    return JSONResponse({"items": request.app.state.api.get_my_scholar_claims(token)})
+
+
 @router.get("/_me")
 def me_proxy(request: Request):
     """Thin proxy so base.html JS can fetch user identity without exposing API_URL."""
@@ -170,6 +303,10 @@ def account(request: Request):
 
     bookmarks = api.get_saved_items({"item_type": "artifact"}, token)
 
+    # Scholar identity (#17): the user's claims drive the "Scholar identity"
+    # account-section (no-claim CTA / pending / rejected / approved + bio editor).
+    scholar_claims = api.get_my_scholar_claims(token)
+
     settings = get_settings()
     from app.main import templates
 
@@ -180,6 +317,7 @@ def account(request: Request):
             "user": user,
             "api_keys": api_keys,
             "bookmarks": bookmarks,
+            "scholar_claims": scholar_claims,
             "api_url": settings.api_url,
         },
     )

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -26,6 +26,40 @@ def _require_admin(request: Request):
     return None
 
 
+@router.get("/scholar-claims")
+def scholar_claims_queue(request: Request, status: str = "pending"):
+    """Admin review queue for scholar claims (#17). Admin-gated; the data comes
+    from the API's admin router over HTTP (two-tier — this page never touches the
+    DB). Filter pills switch the status feed."""
+    guard = _require_admin(request)
+    if guard is not None:
+        return guard
+
+    if status not in ("pending", "approved", "rejected"):
+        status = "pending"
+    token = request.cookies.get("session_token")
+    try:
+        data = request.app.state.api.list_admin_scholar_claims(status, token)
+    except Exception:
+        data = {
+            "items": [],
+            "counts": {"pending": 0, "approved": 0, "rejected": 0},
+            "status": status,
+        }
+
+    from app.main import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/scholar_claims.html",
+        {
+            "claims": data.get("items", []),
+            "counts": data.get("counts", {}),
+            "status": status,
+        },
+    )
+
+
 @router.get("/ingestion")
 def ingestion_dashboard(request: Request):
     """Connector overview: last run, status, open dead-letter count."""

--- a/app/routes/scholars.py
+++ b/app/routes/scholars.py
@@ -6,7 +6,7 @@ router = APIRouter(prefix="/scholars")
 
 
 @router.get("")
-def scholar_list(request: Request):
+def scholar_list(request: Request, claim: int = 0):
     # The all-scholars index (#183). Previously this page was empty until the
     # reader typed a search — a thin, search-first directory. It is now a real
     # *browse* surface: the most productive contributors are rendered on load
@@ -33,6 +33,7 @@ def scholar_list(request: Request):
             "initial_scholars": initial.items,
             "facets": facets,
             "api_url": request.app.state.api.base_url,
+            "claim_mode": bool(claim),
         },
     )
 

--- a/app/static/css/pages/scholar-claim.css
+++ b/app/static/css/pages/scholar-claim.css
@@ -1,0 +1,96 @@
+/* Scholar Identity (#17) — claim prompt, manual confirm, bio editor, admin queue,
+   public verified badge + bio. All token-driven; no raw hex. Lifted verbatim from
+   plan/design/phase3-scholar-identity/prototype.html (render-proven against the
+   real main.css). */
+
+/* — post-login claim prompt — */
+.claim-prompt { display:flex; gap:var(--space-4); align-items:flex-start;
+  background:var(--surface-raised); border:var(--border-subtle);
+  border-left:3px solid var(--color-success); border-radius:var(--radius-md);
+  padding:var(--space-5) var(--space-5); margin-bottom:var(--space-5); }
+.claim-prompt--manual { border-left-color:var(--color-accent); }
+.claim-prompt__icon { flex:0 0 auto; width:40px; height:40px; border-radius:var(--radius-full);
+  display:grid; place-items:center; background:var(--color-success-10); color:var(--color-success); }
+.claim-prompt--manual .claim-prompt__icon { background:var(--color-accent-10); color:var(--color-accent); }
+.claim-prompt__body { flex:1 1 auto; min-width:0; }
+.claim-prompt__title { font:600 var(--text-base)/1.3 var(--font-heading); color:var(--color-text); margin:0 0 var(--space-1); }
+.claim-prompt__match { font-size:var(--text-sm); color:var(--color-text-muted); margin:0 0 var(--space-3); }
+.claim-prompt__match strong { color:var(--color-text); font-weight:600; }
+.claim-prompt__actions { display:flex; gap:var(--space-2); flex-wrap:wrap; }
+
+/* — claim confirm sheet (manual) — */
+.claim-confirm { background:var(--surface-raised); border:var(--border-subtle);
+  border-radius:var(--radius-lg); padding:var(--space-6); max-width:520px; }
+.claim-confirm__head { font:600 var(--text-lg)/1.2 var(--font-heading); color:var(--color-text); margin:0 0 var(--space-2); }
+.claim-confirm__recap { display:flex; gap:var(--space-3); align-items:center; padding:var(--space-3) var(--space-4);
+  background:var(--color-bg-inset); border-radius:var(--radius-md); margin-bottom:var(--space-4); }
+.claim-confirm__recap-name { font-weight:600; color:var(--color-text); }
+.claim-confirm__recap-meta { font-size:var(--text-xs); color:var(--color-text-subtle); }
+.claim-confirm__hint { font-size:var(--text-sm); color:var(--color-text-muted); margin:0 0 var(--space-4); }
+.claim-confirm__actions { display:flex; gap:var(--space-2); margin-top:var(--space-4); }
+
+/* — claim-mode index row "this is me" — */
+.claim-row { display:flex; align-items:center; gap:var(--space-3); justify-content:space-between;
+  padding:var(--space-3) var(--space-4); border-bottom:var(--border-subtle); }
+.claim-row__name { font-weight:500; color:var(--color-text); }
+.claim-row__meta { font-size:var(--text-xs); color:var(--color-text-subtle); }
+
+/* — account: claim status — */
+.claim-status { display:flex; align-items:center; gap:var(--space-3); flex-wrap:wrap;
+  padding:var(--space-4); background:var(--surface-raised); border:var(--border-subtle); border-radius:var(--radius-md); }
+.claim-status__name { font-weight:600; color:var(--color-text); }
+.claim-status__date { font-size:var(--text-xs); color:var(--color-text-subtle); }
+.claim-status__reason { width:100%; font-size:var(--text-sm); color:var(--color-text-muted);
+  border-left:2px solid var(--color-danger); padding-left:var(--space-3); margin-top:var(--space-2); }
+
+/* — bio editor — */
+.bio-editor { display:flex; flex-direction:column; gap:var(--space-4); margin-top:var(--space-4); }
+.bio-editor__charcount { font:var(--text-xs)/1 var(--font-mono); color:var(--color-text-subtle); text-align:right; }
+.bio-editor__actions { display:flex; align-items:center; gap:var(--space-3); }
+.bio-editor__status { font-size:var(--text-sm); color:var(--color-success); }
+.bio-editor__status.is-error { color:var(--color-danger); }
+
+/* — admin review queue — */
+.queue-stat { font:var(--text-sm) var(--font-mono); color:var(--color-text-muted); margin-bottom:var(--space-4); }
+.queue-stat strong { color:var(--color-text); }
+.queue-pills { display:flex; gap:var(--space-2); margin-bottom:var(--space-4); }
+.queue-pill { font-size:var(--text-xs); padding:var(--space-1) var(--space-3); border-radius:var(--radius-full);
+  border:var(--border-subtle); background:transparent; color:var(--color-text-muted); cursor:pointer; text-decoration:none; }
+.queue-pill[data-state="active"] { background:var(--color-accent-10); color:var(--color-accent); border-color:var(--color-accent-30); }
+.queue-list { display:flex; flex-direction:column; }
+.queue-row { display:grid; grid-template-columns:1.1fr 1fr auto; gap:var(--space-4); align-items:start;
+  padding:var(--space-4); border-bottom:var(--border-subtle); }
+.queue-row__label { font:600 var(--text-2xs)/1 var(--font-mono); letter-spacing:.06em; text-transform:uppercase;
+  color:var(--color-text-subtle); margin-bottom:var(--space-1); }
+.queue-row__val { color:var(--color-text); font-size:var(--text-sm); }
+.queue-row__sub { color:var(--color-text-subtle); font-size:var(--text-xs); }
+.queue-row__note { grid-column:1 / -1; font-size:var(--text-sm); color:var(--color-text-muted);
+  background:var(--color-bg-inset); border-radius:var(--radius-sm); padding:var(--space-2) var(--space-3); }
+.queue-row__actions { display:flex; flex-direction:column; gap:var(--space-2); }
+.queue-row__reject-reason { grid-column:1 / -1; margin-top:var(--space-2); }
+
+/* — public scholar page: verified badge + bio — */
+.scholar-id__claim-badge { display:inline-flex; align-items:center; gap:var(--space-1);
+  font-size:var(--text-xs); font-weight:600; padding:var(--space-1) var(--space-2);
+  border-radius:var(--radius-full); background:var(--color-badge-green-bg);
+  color:var(--color-badge-green-text); border:1px solid var(--color-badge-green-border); cursor:help; }
+.scholar-edited { font-size:var(--text-2xs); color:var(--color-text-subtle); font-style:italic; }
+.scholar-bio { display:flex; gap:var(--space-5); align-items:flex-start;
+  background:var(--surface-raised); border:var(--border-subtle); border-radius:var(--radius-md);
+  padding:var(--space-5); margin:var(--space-5) 0; }
+.scholar-bio__avatar { flex:0 0 auto; width:64px; height:64px; border-radius:var(--radius-full);
+  background:var(--color-accent-20); color:var(--color-accent); display:grid; place-items:center;
+  font:600 var(--text-2xl) var(--font-heading); overflow:hidden; }
+.scholar-bio__avatar img { width:100%; height:100%; object-fit:cover; }
+.scholar-bio__body { flex:1 1 auto; min-width:0; }
+.scholar-bio__heading { font:600 var(--text-2xs)/1 var(--font-mono); letter-spacing:.06em;
+  text-transform:uppercase; color:var(--color-text-subtle); margin:0 0 var(--space-2); }
+.scholar-bio__text { font-size:var(--text-sm); line-height:1.6; color:var(--color-text); margin:0; white-space:pre-wrap; }
+.scholar-bio__links { margin-top:var(--space-2); font-size:var(--text-sm); }
+
+/* mobile (390px): queue rows stack, bio stacks (zero horizontal overflow) */
+@media (max-width: 600px) {
+  .queue-row { grid-template-columns:1fr; }
+  .queue-row__actions { flex-direction:row; }
+  .scholar-bio { flex-direction:column; gap:var(--space-3); }
+}

--- a/app/static/js/scholar-claim-prompt.js
+++ b/app/static/js/scholar-claim-prompt.js
@@ -1,0 +1,146 @@
+/**
+ * scholar-claim-prompt.js — the post-login scholar-claim prompt (#17).
+ *
+ * A single dismissible banner shown once after login, mounted into
+ * #scholar-claim-prompt-mount. Two variants:
+ *   - ORCID auto-match: the user's ORCID matched an unclaimed scholar record.
+ *     "Yes, this is me" POSTs the claim (instant verified for an ORCID match) and
+ *     flips the card to a success state.
+ *   - manual nudge: no ORCID match AND the user has no claim yet → a quieter
+ *     "Are you a published scholar?" card linking to the scholars index in claim
+ *     mode (/scholars?claim=1).
+ *
+ * Self-gating, so it degrades quietly:
+ *   - only runs on home / scholars listing / account (not deep in a record);
+ *   - only for a logged-in user (the /_me proxy returns identity or 204);
+ *   - dismissed per-scholar (ORCID) or globally (manual) via localStorage so it
+ *     never nags;
+ *   - any probe error → no banner (spec: degrade quietly, never a crash).
+ *
+ * Two-tier: it only ever calls the app-side /_me* proxies, never the API host.
+ */
+(function () {
+    'use strict';
+
+    var path = window.location.pathname;
+    // Show only on light, top-level surfaces — not while reading a record.
+    var allowed = path === '/' || path === '/scholars' || path === '/account';
+    if (!allowed) return;
+    // Suppress on the scholars index when it's already in claim mode.
+    if (path === '/scholars' && window.location.search.indexOf('claim=1') !== -1) return;
+
+    var mount = document.getElementById('scholar-claim-prompt-mount');
+    if (!mount) return;
+
+    function dismissed(key) {
+        try { return localStorage.getItem(key) === '1'; } catch (e) { return false; }
+    }
+    function dismiss(key) {
+        try { localStorage.setItem(key, '1'); } catch (e) { /* ignore */ }
+    }
+
+    // 1) Are we logged in? /_me returns 204 when there's no session.
+    fetch('/_me')
+        .then(function (r) { return r.status === 204 ? null : r.json(); })
+        .then(function (user) {
+            if (!user) return;  // logged out → no prompt
+            return fetch('/_me/orcid-match')
+                .then(function (r) { return r.ok ? r.json() : { match: null }; })
+                .then(function (om) {
+                    if (om && om.match && !dismissed('claimPrompt:scholar:' + om.match.id)) {
+                        renderOrcid(om.match);
+                        return;
+                    }
+                    // No ORCID match → manual nudge, but only if no claim yet.
+                    if (dismissed('claimPrompt:manual')) return;
+                    return fetch('/_me/scholar-claims')
+                        .then(function (r) { return r.ok ? r.json() : { items: [] }; })
+                        .then(function (cl) {
+                            var items = (cl && cl.items) || [];
+                            if (items.length === 0) renderManual();
+                        });
+                });
+        })
+        .catch(function () { /* degrade quietly */ });
+
+    function show(html) {
+        mount.innerHTML = html;
+        mount.removeAttribute('hidden');
+    }
+
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    function renderOrcid(match) {
+        var meta = esc(match.name);
+        if (match.institution) meta += ' · ' + esc(match.institution);
+        if (match.publication_count) meta += ' · ' + match.publication_count + ' publications on record';
+        show(
+            '<div class="claim-prompt" style="margin-top:var(--space-5)">' +
+              '<div class="claim-prompt__icon" aria-hidden="true">' +
+                '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg>' +
+              '</div>' +
+              '<div class="claim-prompt__body">' +
+                '<p class="claim-prompt__title">We found your scholar record</p>' +
+                '<p class="claim-prompt__match">Your ORCID matches <strong>' + esc(match.name) + '</strong>' +
+                  (match.institution ? ' · ' + esc(match.institution) : '') +
+                  (match.publication_count ? ' · ' + match.publication_count + ' publications on record.' : '.') +
+                '</p>' +
+                '<div class="claim-prompt__actions">' +
+                  '<button class="btn btn--sm btn--primary" id="claim-prompt-yes">Yes, this is me</button>' +
+                  '<button class="btn btn--sm btn--ghost" id="claim-prompt-no">Not me</button>' +
+                '</div>' +
+              '</div>' +
+            '</div>'
+        );
+        document.getElementById('claim-prompt-no').addEventListener('click', function () {
+            dismiss('claimPrompt:scholar:' + match.id);
+            mount.setAttribute('hidden', '');
+        });
+        document.getElementById('claim-prompt-yes').addEventListener('click', function () {
+            var btn = document.getElementById('claim-prompt-yes');
+            btn.disabled = true;
+            fetch('/_me/scholar-claims', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ scholar_id: match.id }),
+            }).then(function (res) {
+                if (res.ok) {
+                    dismiss('claimPrompt:scholar:' + match.id);
+                    mount.querySelector('.claim-prompt__title').textContent = 'Verified ✓';
+                    mount.querySelector('.claim-prompt__match').innerHTML =
+                        'You are now the verified scholar for <strong>' + esc(match.name) + '</strong>. ' +
+                        '<a href="/account#scholar-identity">Edit your profile</a>.';
+                    mount.querySelector('.claim-prompt__actions').innerHTML = '';
+                } else {
+                    btn.disabled = false;
+                }
+            }).catch(function () { btn.disabled = false; });
+        });
+    }
+
+    function renderManual() {
+        show(
+            '<div class="claim-prompt claim-prompt--manual" style="margin-top:var(--space-5)">' +
+              '<div class="claim-prompt__icon" aria-hidden="true">' +
+                '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>' +
+              '</div>' +
+              '<div class="claim-prompt__body">' +
+                '<p class="claim-prompt__title">Are you a published scholar?</p>' +
+                '<p class="claim-prompt__match">Claim your record so your contributions are attributed to you and you can maintain your profile.</p>' +
+                '<div class="claim-prompt__actions">' +
+                  '<a class="btn btn--sm btn--secondary" href="/scholars?claim=1">Find my record</a>' +
+                  '<button class="btn btn--sm btn--ghost" id="claim-prompt-dismiss">Dismiss</button>' +
+                '</div>' +
+              '</div>' +
+            '</div>'
+        );
+        document.getElementById('claim-prompt-dismiss').addEventListener('click', function () {
+            dismiss('claimPrompt:manual');
+            mount.setAttribute('hidden', '');
+        });
+    }
+})();

--- a/app/templates/account/index.html
+++ b/app/templates/account/index.html
@@ -4,6 +4,7 @@
 
 {% block head %}
 <link rel="stylesheet" href="/static/css/pages/account.css?v={{ app_version }}">
+<link rel="stylesheet" href="/static/css/pages/scholar-claim.css?v={{ app_version }}">
 {% endblock %}
 
 {% block content %}
@@ -130,6 +131,67 @@
                 <span id="password-status" class="account-password-status" role="status" aria-live="polite"></span>
             </div>
         </form>
+    </section>
+
+    {# Scholar identity (#17) — claim status + bio editor #}
+    {% set approved_claim = (scholar_claims | selectattr('status', 'equalto', 'approved') | first) %}
+    {% set pending_claim  = (scholar_claims | selectattr('status', 'equalto', 'pending')  | first) %}
+    {% set rejected_claim = (scholar_claims | selectattr('status', 'equalto', 'rejected') | rejectattr('review_note', 'equalto', 'Withdrawn by user') | first) %}
+    <section class="account-section" id="scholar-identity">
+        <h2 class="account-section-title">Scholar identity</h2>
+
+        {% if approved_claim %}
+        <div class="claim-status">
+            <span class="badge badge--green">Verified</span>
+            <a href="/scholars/{{ approved_claim.scholar_id }}" class="claim-status__name">{{ approved_claim.scholar_name }}</a>
+            <span class="claim-status__date">
+                {% if approved_claim.verification_method == 'orcid_match' %}Claimed via ORCID{% else %}Claimed{% endif %}
+                {% if approved_claim.verified_at %} · {{ approved_claim.verified_at | string | truncate(10, true, '') }}{% endif %}
+            </span>
+        </div>
+        <form class="bio-editor" id="bio-editor" data-scholar-id="{{ approved_claim.scholar_id }}">
+            <div class="form-group">
+                <label class="form-label" for="bio">Biography</label>
+                <textarea class="form-input" id="bio" name="bio" rows="4" maxlength="1500" placeholder="A short scholarly biography…">{{ approved_claim.bio or '' }}</textarea>
+                <div class="bio-editor__charcount" id="bio-charcount">0 / 1500</div>
+            </div>
+            <div class="form-group">
+                <label class="form-label" for="inst">Institution</label>
+                <input class="form-input" id="inst" name="institution" value="{{ approved_claim.institution or '' }}">
+            </div>
+            <div class="form-group">
+                <label class="form-label" for="home">Homepage</label>
+                <input class="form-input" id="home" name="homepage_url" value="{{ approved_claim.homepage_url or '' }}">
+            </div>
+            <div class="form-group">
+                <label class="form-label" for="exp">Expertise — periods</label>
+                <input class="form-input" id="exp" name="expertise_periods" value="{{ approved_claim.expertise_periods or '' }}">
+            </div>
+            <div class="bio-editor__actions">
+                <button type="submit" class="btn btn--sm btn--primary">Save profile</button>
+                <span class="bio-editor__status" id="bio-status" role="status" aria-live="polite"></span>
+            </div>
+        </form>
+        {% elif pending_claim %}
+        <div class="claim-status">
+            <span class="badge badge--muted">Under review</span>
+            <span class="claim-status__name">{{ pending_claim.scholar_name }}</span>
+            <span class="claim-status__date">Submitted {{ pending_claim.claimed_at | string | truncate(10, true, '') }}</span>
+            <button class="btn btn--ghost btn--sm" style="margin-left:auto" data-withdraw-claim="{{ pending_claim.id }}">Withdraw</button>
+        </div>
+        {% elif rejected_claim %}
+        <div class="claim-status">
+            <span class="badge badge--muted" style="color:var(--color-danger)">Not approved</span>
+            <span class="claim-status__name">{{ rejected_claim.scholar_name }}</span>
+            <a href="/scholars?claim=1" class="btn btn--ghost btn--sm" style="margin-left:auto">Try again</a>
+            {% if rejected_claim.review_note %}
+            <p class="claim-status__reason">Reason: {{ rejected_claim.review_note }}</p>
+            {% endif %}
+        </div>
+        {% else %}
+        <p class="account-section-description">You haven't claimed a scholar record.</p>
+        <a href="/scholars?claim=1" class="btn btn--sm btn--secondary">Find my record</a>
+        {% endif %}
     </section>
 
     {# Collections quick link #}
@@ -269,6 +331,60 @@ document.getElementById('password-form').addEventListener('submit', async (e) =>
         status.textContent = 'Could not save password. Please try again.';
         status.classList.add('is-error');
     }
+});
+
+// Scholar identity — bio editor (#17). Same save grammar as the password form:
+// inline save, live char count, aria-live status line. PUTs the same-origin proxy.
+const bioEditor = document.getElementById('bio-editor');
+if (bioEditor) {
+    const bioField = document.getElementById('bio');
+    const charCount = document.getElementById('bio-charcount');
+    const bioStatus = document.getElementById('bio-status');
+    const updateCount = () => { charCount.textContent = `${bioField.value.length} / 1500`; };
+    updateCount();
+    bioField.addEventListener('input', updateCount);
+
+    bioEditor.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const scholarId = bioEditor.dataset.scholarId;
+        bioStatus.classList.remove('is-error');
+        bioStatus.textContent = 'Saving…';
+        const payload = {
+            bio: bioField.value,
+            institution: document.getElementById('inst').value,
+            homepage_url: document.getElementById('home').value,
+            expertise_periods: document.getElementById('exp').value,
+        };
+        try {
+            const res = await fetch(`/_me/scholars/${scholarId}/bio`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            if (res.ok) {
+                bioStatus.textContent = 'Saved.';
+            } else {
+                let detail = "Couldn't save — system issue, not your edit.";
+                try { detail = (await res.json()).detail || detail; } catch {}
+                bioStatus.textContent = detail;
+                bioStatus.classList.add('is-error');
+            }
+        } catch {
+            bioStatus.textContent = "Couldn't save — system issue, not your edit.";
+            bioStatus.classList.add('is-error');
+        }
+    });
+}
+
+// Withdraw a pending claim
+document.querySelectorAll('[data-withdraw-claim]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+        const claimId = btn.dataset.withdrawClaim;
+        try {
+            const res = await fetch(`/_me/scholar-claims/${claimId}/withdraw`, { method: 'POST' });
+            if (res.ok) location.reload();
+        } catch {}
+    });
 });
 
 // Remove bookmark

--- a/app/templates/admin/scholar_claims.html
+++ b/app/templates/admin/scholar_claims.html
@@ -1,0 +1,142 @@
+{% extends "base.html" %}
+{% block title %}Scholar claims · Glintstone{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="/static/css/pages/scholar-claim.css?v={{ app_version }}">
+{% endblock %}
+
+{% block content %}
+<main class="container">
+  <div class="page-header">
+    <div class="page-header-main">
+      <div class="page-header-title"><h1>Scholar claims</h1></div>
+    </div>
+  </div>
+
+  {% set pending_n = counts.get('pending', 0) %}
+  <p class="queue-stat"><strong>{{ pending_n }}</strong> claim{{ '' if pending_n == 1 else 's' }} awaiting review</p>
+
+  <div class="queue-pills">
+    <a class="queue-pill" href="/admin/scholar-claims?status=pending" {% if status == 'pending' %}data-state="active"{% endif %}>Pending ({{ counts.get('pending', 0) }})</a>
+    <a class="queue-pill" href="/admin/scholar-claims?status=approved" {% if status == 'approved' %}data-state="active"{% endif %}>Approved</a>
+    <a class="queue-pill" href="/admin/scholar-claims?status=rejected" {% if status == 'rejected' %}data-state="active"{% endif %}>Rejected</a>
+  </div>
+
+  {% if not claims %}
+  <p class="text-muted">
+    {% if status == 'pending' %}No claims awaiting review.{% else %}No {{ status }} claims.{% endif %}
+  </p>
+  {% else %}
+  <div class="queue-list">
+    {% for c in claims %}
+    <div class="queue-row" data-claim-id="{{ c.id }}">
+      <div>
+        <div class="queue-row__label">Claimant</div>
+        <div class="queue-row__val">{{ c.user_display_name or c.user_email }}</div>
+        <div class="queue-row__sub">{{ c.user_email }} · {% if c.user_orcid %}{{ c.user_orcid }}{% else %}no ORCID{% endif %}</div>
+      </div>
+      <div>
+        <div class="queue-row__label">Claiming</div>
+        <div class="queue-row__val">{{ c.scholar_name }}</div>
+        <div class="queue-row__sub">
+          {% if c.scholar_institution %}{{ c.scholar_institution }} · {% endif %}{{ c.scholar_publication_count or 0 }} pubs · submitted {{ c.claimed_at | string | truncate(10, true, '') }}
+        </div>
+      </div>
+      {% if status == 'pending' %}
+      <div class="queue-row__actions">
+        <button class="btn btn--sm btn--primary" data-approve="{{ c.id }}">Approve</button>
+        <button class="btn btn--sm btn--ghost" data-reject-start="{{ c.id }}">Reject</button>
+      </div>
+      {% else %}
+      <div class="queue-row__actions">
+        <span class="badge {% if status == 'approved' %}badge--green{% else %}badge--muted{% endif %}">{{ status | capitalize }}</span>
+        {% if c.verified_by_name %}<span class="queue-row__sub">by {{ c.verified_by_name }}</span>{% endif %}
+      </div>
+      {% endif %}
+
+      {% if c.claim_note %}
+      <div class="queue-row__note">“{{ c.claim_note }}”</div>
+      {% endif %}
+      {% if c.review_note and status == 'rejected' %}
+      <div class="queue-row__note">Reason: {{ c.review_note }}</div>
+      {% endif %}
+
+      {% if status == 'pending' %}
+      <div class="queue-row__reject-reason form-group" id="reject-{{ c.id }}" hidden>
+        <label class="form-label" for="rr-{{ c.id }}">Reason for rejection (shown to the claimant) — required</label>
+        <input class="form-input" id="rr-{{ c.id }}" type="text">
+        <div style="margin-top:var(--space-2)">
+          <button class="btn btn--sm btn--secondary" data-reject-confirm="{{ c.id }}">Confirm rejection</button>
+        </div>
+        <p class="bio-editor__status is-error" id="reject-status-{{ c.id }}" role="status" aria-live="polite"></p>
+      </div>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+// Admin review queue (#17). Approve is one click; Reject is two-step (reveal a
+// required reason field, then confirm) so a reject never reaches the claimant
+// with no explanation. POSTs the same-origin proxy → API admin verify route.
+(function () {
+    'use strict';
+
+    function verify(claimId, action, reviewNote, statusEl) {
+        return fetch('/_me/admin/scholar-claims/' + claimId + '/verify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: action, review_note: reviewNote || null }),
+        }).then(function (res) {
+            if (res.ok) {
+                var row = document.querySelector('.queue-row[data-claim-id="' + claimId + '"]');
+                if (row) row.remove();
+                return true;
+            }
+            return res.json().then(function (j) {
+                if (statusEl) statusEl.textContent = (j && j.detail) || 'Could not record the decision.';
+                return false;
+            }).catch(function () {
+                if (statusEl) statusEl.textContent = 'Could not record the decision.';
+                return false;
+            });
+        });
+    }
+
+    document.querySelectorAll('[data-approve]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            btn.disabled = true;
+            verify(btn.dataset.approve, 'approve', null, null).then(function (ok) {
+                if (!ok) btn.disabled = false;
+            });
+        });
+    });
+
+    document.querySelectorAll('[data-reject-start]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var id = btn.dataset.rejectStart;
+            var panel = document.getElementById('reject-' + id);
+            if (panel) { panel.hidden = false; document.getElementById('rr-' + id).focus(); }
+        });
+    });
+
+    document.querySelectorAll('[data-reject-confirm]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var id = btn.dataset.rejectConfirm;
+            var reason = document.getElementById('rr-' + id).value.trim();
+            var statusEl = document.getElementById('reject-status-' + id);
+            statusEl.textContent = '';
+            if (!reason) { statusEl.textContent = 'A reason is required.'; return; }
+            btn.disabled = true;
+            verify(id, 'reject', reason, statusEl).then(function (ok) {
+                if (!ok) btn.disabled = false;
+            });
+        });
+    });
+})();
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -81,6 +81,11 @@
         </div>
     </header>
 
+    {# Post-login scholar-claim prompt (#17) — injected client-side by
+       scholar-claim-prompt.js when the orcid-match probe hits or the user has no
+       claim yet. Dismissed per-scholar via localStorage so it never nags. #}
+    <div class="container" id="scholar-claim-prompt-mount" hidden></div>
+
     {% block content %}{% endblock %}
 
     <script src="/static/js/app.js?v={{ app_version }}"></script>
@@ -90,5 +95,9 @@
     {% block scripts %}{% endblock %}
     {# Header user chip — extracted from an inline IIFE to header-auth.js (F-5, #125). #}
     <script src="/static/js/header-auth.js?v={{ app_version }}" defer></script>
+    {# Post-login scholar-claim prompt (#17). Self-gates: only logged-in users,
+       only the home/scholars/account areas, dismissed per-scholar. #}
+    <link rel="stylesheet" href="/static/css/pages/scholar-claim.css?v={{ app_version }}">
+    <script src="/static/js/scholar-claim-prompt.js?v={{ app_version }}" defer></script>
 </body>
 </html>

--- a/app/templates/scholars/detail.html
+++ b/app/templates/scholars/detail.html
@@ -6,6 +6,7 @@
 
 {% block head %}
 <link rel="stylesheet" href="/static/css/pages/scholars.css?v={{ app_version }}">
+<link rel="stylesheet" href="/static/css/pages/scholar-claim.css?v={{ app_version }}">
 {% endblock %}
 
 {#
@@ -131,13 +132,18 @@
       <div class="page-header-title">
         <div class="scholar-id__namerow">
           <h1>{{ scholar.name }}</h1>
-          {% if scholar.author_type %}
+          {% if scholar.claim and scholar.claim.verified %}
+          <span class="scholar-id__claim-badge" title="This profile is maintained by the scholar, identity verified.">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+            Claimed · verified
+          </span>
+          {% elif scholar.author_type %}
           <span class="scholar-id__type">{{ scholar.author_type }}</span>
           {% endif %}
         </div>
         <div class="scholar-id__meta">
           {% if scholar.institution %}
-          <span><strong>{{ scholar.institution }}</strong></span>
+          <span><strong>{{ scholar.institution }}</strong>{% if scholar.institution_overridden %} <span class="scholar-edited">· edited by this scholar</span>{% endif %}</span>
           {% endif %}
           {% if scholar.active_since %}
           <span>Active since <strong>{{ scholar.active_since }}</strong></span>
@@ -221,6 +227,27 @@
     </div>
     {% endif %}
   </header>
+
+  {# Verified-claim bio block (#17) — rendered only for an approved claim with a
+     bio override. Pending/unclaimed scholars show nothing here (spec decision #4). #}
+  {% if scholar.claim and scholar.claim.verified and (scholar.bio or scholar.homepage_url) %}
+  <div class="scholar-bio">
+    <div class="scholar-bio__avatar" aria-hidden="true">
+      {% if scholar.avatar_url %}
+      <img src="{{ scholar.avatar_url }}" alt="">
+      {% else %}{{ (scholar.name or '?')[0] | upper }}{% endif %}
+    </div>
+    <div class="scholar-bio__body">
+      <p class="scholar-bio__heading">Biography</p>
+      {% if scholar.bio %}
+      <p class="scholar-bio__text">{{ scholar.bio }}</p>
+      {% endif %}
+      {% if scholar.homepage_url %}
+      <p class="scholar-bio__links"><a href="{{ scholar.homepage_url }}" target="_blank" rel="noopener">{{ scholar.homepage_url | replace('https://', '') | replace('http://', '') }}</a></p>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
 
   {# Publications & works ledger (#206) — most-cited-first, the richer surface,
      rendered before contributions per the spec default. #}

--- a/app/templates/scholars/list.html
+++ b/app/templates/scholars/list.html
@@ -4,6 +4,7 @@
 
 {% block head %}
 <link rel="stylesheet" href="/static/css/pages/scholars.css?v={{ app_version }}">
+{% if claim_mode %}<link rel="stylesheet" href="/static/css/pages/scholar-claim.css?v={{ app_version }}">{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -12,7 +13,7 @@
    ranked list renders server-side on load; the facet rail (#194) and live
    search enhance it client-side. JS-off, the page is still a meaningful,
    ranked directory of contributors. #}
-<main class="scholars-page" data-api-url="{{ api_url }}">
+<main class="scholars-page" data-api-url="{{ api_url }}" data-claim-mode="{{ '1' if claim_mode else '0' }}">
     <div class="scholars-layout">
 
         {# ── Discovery rail (left) — facet counts (#194) ──────────────── #}
@@ -116,6 +117,12 @@
                                 {% if c == 1 %}1 artifact{% else %}{{ '{:,}'.format(c) }} artifacts{% endif %}
                             </span>
                         </a>
+                        {% if claim_mode %}
+                        <button type="button" class="btn btn--sm btn--ghost scholars-row__claim"
+                                data-claim-id="{{ scholar.id }}"
+                                data-claim-name="{{ scholar.name }}"
+                                data-claim-institution="{{ scholar.institution or '' }}">This is me</button>
+                        {% endif %}
                     </li>
                     {% endfor %}
                 </ul>
@@ -132,7 +139,87 @@
             </div>
         </div>
     </div>
+
+    {% if claim_mode %}
+    {# Claim confirm sheet (#17) — revealed when "This is me" is clicked. #}
+    <div class="claim-confirm" id="claim-confirm" hidden style="margin-top:var(--space-6)">
+        <p class="claim-confirm__head">Claim this scholar record</p>
+        <div class="claim-confirm__recap">
+            <div>
+                <div class="claim-confirm__recap-name" id="claim-confirm-name"></div>
+                <div class="claim-confirm__recap-meta" id="claim-confirm-meta"></div>
+            </div>
+        </div>
+        <p class="claim-confirm__hint">No ORCID on this record, so an editor will review your claim. Briefly, how can we verify this is you?</p>
+        <div class="form-group">
+            <label class="form-label" for="claim-note">Verification note (optional)</label>
+            <textarea class="form-input" id="claim-note" rows="3" placeholder="e.g. my homepage, a recent paper, or my institutional page"></textarea>
+        </div>
+        <div class="claim-confirm__actions">
+            <button type="button" class="btn btn--sm btn--primary" id="claim-submit">Submit claim</button>
+            <button type="button" class="btn btn--sm btn--ghost" id="claim-cancel">Cancel</button>
+        </div>
+        <p class="bio-editor__status" id="claim-confirm-status" role="status" aria-live="polite"></p>
+    </div>
+    {% endif %}
 </main>
+
+{% if claim_mode %}
+<script>
+// Manual claim flow (#17) — "This is me" reveals the confirm sheet; submit POSTs
+// the same-origin proxy. ORCID-bearing records auto-approve server-side; the
+// rest go pending to the admin queue.
+(function () {
+    'use strict';
+    const sheet = document.getElementById('claim-confirm');
+    const nameEl = document.getElementById('claim-confirm-name');
+    const metaEl = document.getElementById('claim-confirm-meta');
+    const noteEl = document.getElementById('claim-note');
+    const statusEl = document.getElementById('claim-confirm-status');
+    let activeId = null;
+
+    document.querySelector('.scholars-page').addEventListener('click', (e) => {
+        const btn = e.target.closest('.scholars-row__claim');
+        if (!btn) return;
+        activeId = btn.dataset.claimId;
+        nameEl.textContent = btn.dataset.claimName || '';
+        metaEl.textContent = btn.dataset.claimInstitution || '';
+        statusEl.textContent = '';
+        statusEl.classList.remove('is-error');
+        sheet.hidden = false;
+        sheet.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+
+    document.getElementById('claim-cancel').addEventListener('click', () => {
+        sheet.hidden = true; activeId = null;
+    });
+
+    document.getElementById('claim-submit').addEventListener('click', async () => {
+        if (!activeId) return;
+        statusEl.classList.remove('is-error');
+        statusEl.textContent = 'Submitting…';
+        try {
+            const res = await fetch('/_me/scholar-claims', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ scholar_id: Number(activeId), claim_note: noteEl.value || null }),
+            });
+            if (res.ok) {
+                window.location.href = '/account#scholar-identity';
+            } else {
+                let detail = 'This record is already claimed.';
+                try { detail = (await res.json()).detail || detail; } catch {}
+                statusEl.textContent = detail;
+                statusEl.classList.add('is-error');
+            }
+        } catch {
+            statusEl.textContent = 'Could not submit — please try again.';
+            statusEl.classList.add('is-error');
+        }
+    });
+})();
+</script>
+{% endif %}
 
 <script>
 (function () {
@@ -140,6 +227,7 @@
 
     const page = document.querySelector('.scholars-page');
     const API_BASE = (page.dataset.apiUrl || '').replace(/\/$/, '');
+    const CLAIM_MODE = page.dataset.claimMode === '1';
 
     const input = document.getElementById('scholars-search');
     const list = document.getElementById('scholars-list');
@@ -187,12 +275,18 @@
         const institutionHtml = scholar.institution
             ? '<span class="scholars-row__institution">' + escapeHtml(scholar.institution) + '</span>'
             : '';
+        const claimBtn = CLAIM_MODE
+            ? '<button type="button" class="btn btn--sm btn--ghost scholars-row__claim"' +
+              ' data-claim-id="' + scholar.id + '"' +
+              ' data-claim-name="' + escapeHtml(scholar.name) + '"' +
+              ' data-claim-institution="' + escapeHtml(scholar.institution || '') + '">This is me</button>'
+            : '';
         li.innerHTML =
             '<a class="scholars-row__link" href="/scholars/' + scholar.id + '">' +
                 '<span class="scholars-row__name">' + escapeHtml(scholar.name) + '</span>' +
                 institutionHtml +
                 '<span class="scholars-row__count">' + countText + '</span>' +
-            '</a>';
+            '</a>' + claimBtn;
         return li;
     }
 

--- a/data-model/glintstone-schema.yaml
+++ b/data-model/glintstone-schema.yaml
@@ -742,6 +742,54 @@ tables:
       expertise_languages: { type: TEXT, nullable: true, description: "JSON array of language codes (sux, akk, etc.)" }
       active_since: { type: TEXT, nullable: true, description: "Year of first publication" }
 
+  scholar_claims:
+    # ORIGIN: Migration 060 (#17 Scholar Identity keystone). Created when a logged-in
+    #         user claims a scholars row as their own identity.
+    # CONNECTS: user_id → users.id (uuid), scholar_id → scholars.id (integer). Bridges the
+    #           PK-type mismatch between live users and ORACC-ingested scholars.
+    # TRADE-OFF: A partial unique index enforces ONE approved claim per scholar (a scholar is
+    #            one person); a separate partial unique index blocks duplicate PENDING claims by
+    #            the same user. ORCID match auto-approves; manual claims go to admin review.
+    description: >
+      NEW TABLE (migration 060). Links a logged-in user to a scholar record they
+      claim as their identity. ORCID match → approved instantly; otherwise pending
+      until an admin reviews. The trust primitive #262 attribution depends on.
+    columns:
+      id: { type: uuid, pk: true, description: "gen_random_uuid()" }
+      user_id: { type: uuid, not_null: true, description: "FK users.id ON DELETE CASCADE" }
+      scholar_id: { type: INTEGER, not_null: true, description: "FK scholars.id ON DELETE CASCADE" }
+      status: { type: TEXT, not_null: true, values: [pending, approved, rejected] }
+      verification_method: { type: TEXT, not_null: true, values: [orcid_match, manual_review] }
+      claim_note: { type: TEXT, nullable: true, description: "User's evidence message for manual review" }
+      claimed_at: { type: TIMESTAMPTZ, not_null: true, description: "default now()" }
+      verified_at: { type: TIMESTAMPTZ, nullable: true, description: "Set on approve / on insert for orcid_match" }
+      verified_by: { type: uuid, nullable: true, description: "FK users.id; NULL = system (orcid_match)" }
+      review_note: { type: TEXT, nullable: true, description: "Admin's reason on reject, shown to the user" }
+    indexes:
+      - "uq_scholar_claims_approved_scholar UNIQUE (scholar_id) WHERE status='approved'"
+      - "uq_scholar_claims_pending_pair UNIQUE (user_id, scholar_id) WHERE status='pending'"
+
+  scholar_overrides:
+    # ORIGIN: Migration 060 (#17). A re-ingestion-safe overlay for scholar-edited profile
+    #         fields. Sparse: one row per claimed scholar.
+    # CONNECTS: scholar_id PK → scholars.id; edited_by_user_id → users.id.
+    # TRADE-OFF: A SEPARATE overlay table (not columns on scholars) so the ORACC ingestion
+    #            pipeline can never clobber user edits. The read model COALESCE(override, ingested)
+    #            per field — overlay wins when present. Reversible: delete the row → pristine data.
+    description: >
+      NEW TABLE (migration 060). The bio/profile overlay a verified claimant edits.
+      Never mutates the ORACC-ingested scholars row. GET /scholars/{id} LEFT JOINs
+      this and COALESCEs per field.
+    columns:
+      scholar_id: { type: INTEGER, pk: true, description: "FK scholars.id ON DELETE CASCADE" }
+      edited_by_user_id: { type: uuid, not_null: true, description: "FK users.id (the verified claimant)" }
+      bio: { type: TEXT, nullable: true, description: "Short scholarly biography (~1500 char, enforced in API)" }
+      institution: { type: TEXT, nullable: true, description: "Overrides scholars.institution" }
+      homepage_url: { type: TEXT, nullable: true }
+      expertise_periods: { type: TEXT, nullable: true, description: "Overrides scholars.expertise_periods" }
+      expertise_languages: { type: TEXT, nullable: true, description: "Overrides scholars.expertise_languages" }
+      updated_at: { type: TIMESTAMPTZ, not_null: true, description: "default now()" }
+
   annotation_runs:
     # ORIGIN: Created by every import step and every annotation action. Retroactive records
     #         created for all v1 data (13 records for existing CDLI/ORACC/CompVis imports).

--- a/data-model/migrations/060_scholar_claims_and_overrides.sql
+++ b/data-model/migrations/060_scholar_claims_and_overrides.sql
@@ -1,0 +1,85 @@
+-- Migration 060: scholar_claims + scholar_overrides — the Scholar Identity keystone (#17).
+--
+-- Two new tables bridge the two ends that already exist but were never connected:
+--   * `users`    — live people who authenticated (uuid PK, orcid_id, role).
+--   * `scholars` — 20,490 ORACC-ingested records (integer PK, orcid, institution).
+-- There was no way for a logged-in user to say "that scholar record is me." These
+-- tables add that link (scholar_claims) and a re-ingestion-safe place for the
+-- claimant to edit their own bio (scholar_overrides).
+--
+-- PK-type bridge: user_id uuid ↔ scholar_id integer. The mismatch is deliberate
+-- and load-bearing — scholar_claims is the only thing that joins the two.
+--
+-- DECISIONS BAKED IN (designer spec, Eric-approved defaults):
+--   1. ORCID match auto-approves; manual claims always go to admin review.
+--   2. One APPROVED claim per scholar (partial unique index) — a scholar is one
+--      person. A user MAY claim multiple scholar rows (ORACC duplicate records).
+--   3. Bio overlay fields = bio / institution / homepage_url / expertise_* only.
+--   4. Public page shows the verified badge + bio ONLY after approval.
+--
+-- WHY scholar_overrides is a SEPARATE OVERLAY TABLE, not columns on `scholars`:
+--   `scholars` is ORACC-ingested and RE-ingested. A `bio` column on it would be
+--   clobbered on the next ingestion pass. The overlay is a table the ingestion
+--   pipeline never writes, so user edits are structurally safe from re-ingestion
+--   (the CLAUDE.md non-negotiable: never silently overwrite ingested data). The
+--   read model does LEFT JOIN + COALESCE(override, ingested) per field.
+--
+-- GRANT: both tables are owned by wittkensis (migrations run as wittkensis); the
+-- app connects as glintstone, so GRANT the CRUD set after creating each table.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE ... IF NOT EXISTS on every
+-- index, so re-running the migration is a no-op.
+
+BEGIN;
+
+-- ── Part 1: scholar_claims — who claimed which scholar, how, and its status ──
+
+CREATE TABLE IF NOT EXISTS scholar_claims (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id             uuid    NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+    scholar_id          integer NOT NULL REFERENCES scholars(id) ON DELETE CASCADE,
+    status              text    NOT NULL DEFAULT 'pending'
+                          CHECK (status IN ('pending', 'approved', 'rejected')),
+    verification_method text    NOT NULL
+                          CHECK (verification_method IN ('orcid_match', 'manual_review')),
+    claim_note          text,                 -- optional user message ("I am the author of…")
+    claimed_at          timestamptz NOT NULL DEFAULT now(),
+    verified_at         timestamptz,          -- set on approve (or on insert for orcid_match)
+    verified_by         uuid REFERENCES users(id),  -- admin who acted; NULL = system (orcid_match)
+    review_note         text                  -- admin's reason on reject (shown to the user)
+);
+
+-- One APPROVED claim per scholar (decision #2): a scholar is one person. A second
+-- user trying to claim an already-approved record is rejected with 409.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_scholar_claims_approved_scholar
+    ON scholar_claims (scholar_id) WHERE status = 'approved';
+
+-- A user can't file two PENDING claims on the same scholar (no duplicate queue spam).
+-- A rejected row does NOT block a fresh attempt (re-claim after rejection is allowed).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_scholar_claims_pending_pair
+    ON scholar_claims (user_id, scholar_id) WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_scholar_claims_user
+    ON scholar_claims (user_id);
+CREATE INDEX IF NOT EXISTS idx_scholar_claims_status_pending
+    ON scholar_claims (status) WHERE status = 'pending';
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON scholar_claims TO glintstone;
+
+
+-- ── Part 2: scholar_overrides — the bio overlay (sparse; one row per claim) ──
+
+CREATE TABLE IF NOT EXISTS scholar_overrides (
+    scholar_id          integer PRIMARY KEY REFERENCES scholars(id) ON DELETE CASCADE,
+    edited_by_user_id   uuid    NOT NULL REFERENCES users(id),  -- the verified claimant
+    bio                 text,                 -- ~1500 char (enforced in the API, not the DB)
+    institution         text,                 -- overrides scholars.institution
+    homepage_url        text,
+    expertise_periods   text,                 -- overrides scholars.expertise_periods
+    expertise_languages text,                 -- overrides scholars.expertise_languages
+    updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON scholar_overrides TO glintstone;
+
+COMMIT;

--- a/tests/test_scholar_claims.py
+++ b/tests/test_scholar_claims.py
@@ -1,0 +1,355 @@
+"""Integration tests for the Scholar Identity feature (#17).
+
+DB-backed (skipped without DATABASE_URL; runs in CI per #470). Validates
+migration 060's schema and the claim/overlay invariants the feature hinges on:
+
+  - the claim lifecycle (pending → approved / rejected);
+  - the partial unique index enforcing ONE approved claim per scholar;
+  - a user can't file two pending claims on the same scholar;
+  - the scholar_overrides COALESCE read model (overlay wins, reverts on delete);
+  - the bio-edit authorization guard (only the approved claimant);
+  - admin-gating of the verify/queue routes (403 for a standard user);
+  - no auth regression (a magic-link user still authenticates).
+
+These reuse the db_conn / user_repo / test_user fixtures from test_auth_routes.py
+(same package, so pytest discovers them via the shared conftest + that module's
+fixtures are imported below for clarity).
+"""
+
+import uuid
+
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.usefixtures("has_database_url")
+
+
+@pytest.fixture
+def db_conn(has_database_url):
+    from psycopg.rows import dict_row
+
+    conn = psycopg.connect(has_database_url, row_factory=dict_row)
+    conn.autocommit = False
+    yield conn
+    conn.rollback()
+    conn.close()
+
+
+@pytest.fixture
+def a_user(db_conn):
+    """A fresh user with an ORCID, cleaned up on teardown (claims cascade)."""
+    from api.repositories.user_repo import UserRepository
+
+    repo = UserRepository(db_conn)
+    email = f"claim-test-{uuid.uuid4().hex[:8]}@glintstone.example"
+    user = repo.create_user(
+        email=email,
+        display_name="Claim Tester",
+        orcid_id=f"0000-0001-{uuid.uuid4().hex[:4]}-0000",
+    )
+    db_conn.commit()
+    yield user
+    with db_conn.cursor() as cur:
+        cur.execute("DELETE FROM users WHERE id = %s", (user["id"],))
+    db_conn.commit()
+
+
+@pytest.fixture
+def another_user(db_conn):
+    from api.repositories.user_repo import UserRepository
+
+    repo = UserRepository(db_conn)
+    email = f"claim-test2-{uuid.uuid4().hex[:8]}@glintstone.example"
+    user = repo.create_user(email=email, display_name="Second Tester")
+    db_conn.commit()
+    yield user
+    with db_conn.cursor() as cur:
+        cur.execute("DELETE FROM users WHERE id = %s", (user["id"],))
+    db_conn.commit()
+
+
+@pytest.fixture
+def a_scholar(db_conn):
+    """A throwaway scholar row (so claim FKs resolve), removed on teardown."""
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO scholars (name, institution, expertise_periods) "
+            "VALUES (%s, %s, %s) RETURNING id",
+            ("Test, Scholar", "Ingested University", "Ur III"),
+        )
+        sid = cur.fetchone()["id"]
+    db_conn.commit()
+    yield sid
+    with db_conn.cursor() as cur:
+        cur.execute("DELETE FROM scholars WHERE id = %s", (sid,))
+    db_conn.commit()
+
+
+class TestSchema060:
+    def test_tables_exist(self, db_conn):
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_name IN ('scholar_claims', 'scholar_overrides')"
+            )
+            names = {r["table_name"] for r in cur.fetchall()}
+        assert names == {"scholar_claims", "scholar_overrides"}, (
+            "Run migration 060 — scholar_claims / scholar_overrides missing"
+        )
+
+
+class TestClaimLifecycle:
+    def test_pending_then_approve_creates_overlay_shell(
+        self, db_conn, a_user, a_scholar
+    ):
+        with db_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO scholar_claims
+                    (user_id, scholar_id, status, verification_method, claim_note)
+                VALUES (%s, %s, 'pending', 'manual_review', %s)
+                RETURNING id, status
+                """,
+                (a_user["id"], a_scholar, "I am the author"),
+            )
+            claim = cur.fetchone()
+            assert claim["status"] == "pending"
+
+            # Approve: mirror the admin route's side effects.
+            cur.execute(
+                "UPDATE scholar_claims SET status='approved', verified_at=now() "
+                "WHERE id = %s",
+                (claim["id"],),
+            )
+            cur.execute(
+                "INSERT INTO scholar_overrides (scholar_id, edited_by_user_id) "
+                "VALUES (%s, %s) ON CONFLICT (scholar_id) DO NOTHING",
+                (a_scholar, a_user["id"]),
+            )
+            cur.execute(
+                "SELECT 1 FROM scholar_overrides WHERE scholar_id = %s", (a_scholar,)
+            )
+            assert cur.fetchone() is not None
+        db_conn.commit()
+
+    def test_reject_records_reason(self, db_conn, a_user, a_scholar):
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO scholar_claims "
+                "(user_id, scholar_id, status, verification_method) "
+                "VALUES (%s, %s, 'pending', 'manual_review') RETURNING id",
+                (a_user["id"], a_scholar),
+            )
+            cid = cur.fetchone()["id"]
+            cur.execute(
+                "UPDATE scholar_claims SET status='rejected', review_note=%s "
+                "WHERE id = %s",
+                ("Cannot verify identity", cid),
+            )
+            cur.execute(
+                "SELECT status, review_note FROM scholar_claims WHERE id=%s", (cid,)
+            )
+            row = cur.fetchone()
+        assert row["status"] == "rejected"
+        assert row["review_note"] == "Cannot verify identity"
+        db_conn.rollback()
+
+
+class TestOneApprovedClaimPerScholar:
+    def test_partial_unique_index_blocks_second_approved(
+        self, db_conn, a_user, another_user, a_scholar
+    ):
+        """The load-bearing invariant: only one approved claim per scholar."""
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO scholar_claims "
+                "(user_id, scholar_id, status, verification_method) "
+                "VALUES (%s, %s, 'approved', 'orcid_match')",
+                (a_user["id"], a_scholar),
+            )
+        db_conn.commit()
+
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            with db_conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO scholar_claims "
+                    "(user_id, scholar_id, status, verification_method) "
+                    "VALUES (%s, %s, 'approved', 'manual_review')",
+                    (another_user["id"], a_scholar),
+                )
+            db_conn.commit()
+        db_conn.rollback()
+
+    def test_two_pending_by_same_user_blocked(self, db_conn, a_user, a_scholar):
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO scholar_claims "
+                "(user_id, scholar_id, status, verification_method) "
+                "VALUES (%s, %s, 'pending', 'manual_review')",
+                (a_user["id"], a_scholar),
+            )
+        db_conn.commit()
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            with db_conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO scholar_claims "
+                    "(user_id, scholar_id, status, verification_method) "
+                    "VALUES (%s, %s, 'pending', 'manual_review')",
+                    (a_user["id"], a_scholar),
+                )
+            db_conn.commit()
+        db_conn.rollback()
+
+    def test_rejected_does_not_block_reclaim(self, db_conn, a_user, a_scholar):
+        """A rejected row must not block a fresh pending attempt (re-claim allowed)."""
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO scholar_claims "
+                "(user_id, scholar_id, status, verification_method) "
+                "VALUES (%s, %s, 'rejected', 'manual_review')",
+                (a_user["id"], a_scholar),
+            )
+            # A new pending claim by the same user on the same scholar is fine.
+            cur.execute(
+                "INSERT INTO scholar_claims "
+                "(user_id, scholar_id, status, verification_method) "
+                "VALUES (%s, %s, 'pending', 'manual_review') RETURNING id",
+                (a_user["id"], a_scholar),
+            )
+            assert cur.fetchone()["id"] is not None
+        db_conn.rollback()
+
+
+class TestOverlayCoalesce:
+    def test_overlay_wins_and_reverts_on_delete(self, db_conn, a_user, a_scholar):
+        """COALESCE(override, ingested): overlay value wins; deleting it reverts."""
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO scholar_overrides "
+                "(scholar_id, edited_by_user_id, institution, bio) "
+                "VALUES (%s, %s, %s, %s)",
+                (a_scholar, a_user["id"], "Overlay University", "A bio."),
+            )
+            cur.execute(
+                """
+                SELECT COALESCE(o.institution, s.institution) AS institution, o.bio
+                FROM scholars s
+                LEFT JOIN scholar_overrides o ON o.scholar_id = s.id
+                WHERE s.id = %s
+                """,
+                (a_scholar,),
+            )
+            row = cur.fetchone()
+            assert row["institution"] == "Overlay University"
+            assert row["bio"] == "A bio."
+
+            # Delete the overlay → reverts to the ingested institution.
+            cur.execute(
+                "DELETE FROM scholar_overrides WHERE scholar_id = %s", (a_scholar,)
+            )
+            cur.execute(
+                """
+                SELECT COALESCE(o.institution, s.institution) AS institution
+                FROM scholars s
+                LEFT JOIN scholar_overrides o ON o.scholar_id = s.id
+                WHERE s.id = %s
+                """,
+                (a_scholar,),
+            )
+            assert cur.fetchone()["institution"] == "Ingested University"
+        db_conn.rollback()
+
+
+class TestBioEditGuard:
+    def test_only_approved_claimant_passes_guard(
+        self, db_conn, a_user, another_user, a_scholar
+    ):
+        """The guard query the bio-edit route runs: SELECT 1 WHERE approved claim."""
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO scholar_claims "
+                "(user_id, scholar_id, status, verification_method) "
+                "VALUES (%s, %s, 'approved', 'orcid_match')",
+                (a_user["id"], a_scholar),
+            )
+
+            def has_claim(user_id):
+                cur.execute(
+                    "SELECT 1 FROM scholar_claims "
+                    "WHERE scholar_id = %s AND user_id = %s AND status = 'approved'",
+                    (a_scholar, user_id),
+                )
+                return cur.fetchone() is not None
+
+            assert has_claim(a_user["id"]) is True
+            assert has_claim(another_user["id"]) is False
+        db_conn.rollback()
+
+
+class TestAdminGating:
+    """The admin verify/queue routes must reject a standard user (#461 role)."""
+
+    def test_require_admin_rejects_standard_user(self):
+        from fastapi import HTTPException
+        from api.dependencies import require_admin
+
+        class _Req:
+            class state:
+                user = {"id": "u1", "role": "standard"}
+
+        with pytest.raises(HTTPException) as exc:
+            require_admin(_Req())
+        assert exc.value.status_code == 403
+
+    def test_require_admin_allows_admin(self):
+        from api.dependencies import require_admin
+
+        class _Req:
+            class state:
+                user = {"id": "u1", "role": "admin"}
+
+        assert require_admin(_Req())["role"] == "admin"
+
+    def test_require_admin_rejects_anonymous(self):
+        from fastapi import HTTPException
+        from api.dependencies import require_admin
+
+        class _Req:
+            class state:
+                user = None
+
+        with pytest.raises(HTTPException) as exc:
+            require_admin(_Req())
+        assert exc.value.status_code == 401
+
+
+class TestNoAuthRegression:
+    """The claim feature must not break the existing magic-link path."""
+
+    def test_magic_link_user_still_authenticates(self, db_conn):
+        from api.repositories.user_repo import UserRepository
+        from api.repositories.session_repo import SessionRepository
+        from api.services.auth_service import generate_session_token, hash_token
+        from datetime import datetime, timedelta, timezone
+
+        users = UserRepository(db_conn)
+        sessions = SessionRepository(db_conn)
+        email = f"noregress-{uuid.uuid4().hex[:8]}@glintstone.example"
+        user = users.create_user(email=email)
+        users.link_auth_method(user["id"], "magic_link", email)
+        db_conn.commit()
+
+        raw = generate_session_token()
+        token_hash = hash_token(raw)
+        sessions.create_session(
+            user["id"], token_hash, datetime.now(timezone.utc) + timedelta(days=1)
+        )
+        db_conn.commit()
+
+        found = sessions.find_by_token_hash(token_hash)
+        assert found is not None
+        assert found["email"] == email
+
+        with db_conn.cursor() as cur:
+            cur.execute("DELETE FROM users WHERE id = %s", (user["id"],))
+        db_conn.commit()


### PR DESCRIPTION
Closes #17. Scholar Identity keystone.

## What
- Migration 060: `scholar_claims` + `scholar_overrides` + partial unique indexes (one approved claim per scholar; one pending claim per user/scholar), GRANTs to `glintstone`.
- API: `GET /auth/orcid-match`, `POST /auth/scholar-claims`, admin queue at `/admin/scholar-claims`, scholars list `?claim=1` rows.
- Web: bio editor at `/account`, post-login claim prompt, scholar detail verified badge (approved-only), admin review UI.
- Tests: `tests/test_scholar_claims.py` — 12 DB-backed tests (now RUN per #470), incl. a magic-link no-lockout regression guard.

## Safety
- auth.py changes are purely additive — magic-link request/verify untouched (0 removed lines). No-lockout regression test green locally.
- Overlay table keeps user bio edits structurally safe from ORACC re-ingestion.

Local gate green: ruff check + ruff format + mypy (--ignore-missing-imports) + pytest 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)