### PR TITLE
Add gs-swarm + gs-canary to the gs-* family (#29)

### DIFF
--- a/.claude/skills/gs-canary/SKILL.md
+++ b/.claude/skills/gs-canary/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: gs-canary
+description: Read-only blast-radius recon for a Glintstone bug, symptom, or proposed change. Decides whether it's api-only, app-only, or shared (the api↔app contract, the token CSS, a migration, or a gs-expert domain), names the invariant violated, greps both tiers + the migrations + the CSS tokens, and returns which tier(s) are affected and the cheapest CORRECT tier to fix. Use in the triage phase of a gs-swarm (fan out one per symptom, in parallel) BEFORE any fix, or for any single Glintstone bug that smells like it crosses the two-tier seam. Read-only — never edits. Triggers — canary, blast radius, "this smells systemic", "which tier", "api or app", root cause, triage.
+metadata:
+  question: "For a Glintstone bug or change, is it api-only, app-only, or shared — and at what tier is the cheapest correct fix?"
+  created: 2026-06-25
+  modified: 2026-06-25
+  context: "Back-ported from fleet--canary-scout (the *.ericwittke.com fleet recon scout) during backlog #29 Phase 3. The fleet version classifies app-local vs kw-system base vs template across cloned apps. This Glintstone version classifies along Glintstone's actual seams instead: api-only vs app-only vs shared (the api↔app HTTP contract, the token CSS, a migration, or a cross-cutting gs-expert domain). It is the read-only complement to the generic canary-in-the-coalmine class-closing loop."
+  status: active
+  audience: [claude, engineers]
+  owners: [eric]
+  related_issues: ["#29"]
+  related_skills: [gs-swarm, canary-in-the-coalmine, gs-expert-data-model, gs-expert-ui, gs-expert-integrations, gs-expert-deployment, gs-orient-project]
+  supersedes: null
+  superseded_by: null
+  triggers: [canary, "blast radius", "this smells systemic", "which tier", "api or app", "root cause", triage, scout, "systemic bug"]
+---
+
+# Glintstone Canary Scout
+
+## Invocation
+Triggers: canary, blast radius, this smells systemic, which tier, api or app, root cause, triage
+
+Read-only recon: before anyone fixes a Glintstone bug, decide **at what tier it should be fixed** so a one-line symptom isn't patched on both tiers (or patched once in the wrong tier). One symptom per dispatch. You **read and measure only — never edit.** This is the Glintstone-tiered front of the generic `canary-in-the-coalmine` loop; it owns *where*, that skill owns *closing the class*.
+
+A bug is a sample from a distribution. The dead canary isn't the problem — it's the warning that a contract, a token, or a migration is wrong everywhere it's consumed.
+
+## Input
+One symptom/bug/proposed change (e.g. "translation count shows NULL on the artifact page", "lemma filter returns 500", "add a `confidence` field to annotations", "P-number header wraps on mobile"). If a specific tier/file is named, start there; otherwise start from the **api↔app contract** (the endpoint + the template/JS that consumes it).
+
+## Method
+1. **Name the invariant** the bug violates (e.g. "every annotation row carries `annotation_run_id`"; "the app reads counts from the API response, never the DB"; "a new table is `GRANT`ed to `glintstone`"; "P-number headers truncate, not wrap").
+2. **Locate the root — which tier owns the cause?**
+   - **api/** — endpoint, repository, query, serialization, the JSON shape the app consumes.
+   - **app/** — Jinja template, vanilla JS, the httpx call, presentation.
+   - **shared / contract** — the api↔app HTTP contract itself (field renamed/removed in `api/` that `app/` still reads), the **token CSS** (`app/static/`), a **migration** (`source-data/migrations/NNN_*.sql`), or a cross-cutting **gs-expert domain** rule (data-model, assyriology, integrations).
+   Grep both tiers, the migrations, and the CSS tokens. Distinguish "the code is latent here" from "this tier actually triggers it."
+3. **Measure blast radius.** Which tier(s) actually exhibit it, and how many call sites? A renamed API field can break every template that reads it; a missing `GRANT` breaks every app read of that table; a missing token breaks every component using it. Report counts + `file:line`s per tier. "api-only, 1 endpoint" vs "contract drift across 6 templates" changes the fix.
+4. **Pick the tier.** api-only (one endpoint/repo) → app-only (template/JS) → shared. For **shared**, name the sub-class:
+   | Sub-class | Meaning | Fix at |
+   |---|---|---|
+   | **Contract drift** | api/ and app/ disagree on the JSON shape | fix the `api/` contract once; update every `app/` consumer |
+   | **Token / CSS** | a design token or base style is wrong/missing | fix the token in `app/static/`; re-check every component |
+   | **Migration** | schema/grant/index wrong → every consumer affected | new `NNN_*.sql` migration (as `wittkensis`, `GRANT` to `glintstone`) |
+   | **gs-expert domain** | a cross-cutting domain rule (attribution, lemma parsing, source quirk) | fix in the domain layer per the owning gs-expert skill |
+   Cheapest tier that fixes it everywhere it can occur, without over-reaching.
+5. **Codify hook.** If shared, note where it should be guarded so it can't recur — a `gs-audit-hardening` / `gs-audit-frontend` dimension, a pytest assertion on the contract, a `GRANT` check, or a tightening of the owning gs-expert skill. Name the owning gs-expert so the fix lands with the right expert.
+
+## Glintstone-specific traps to check before classifying
+- **Two-tier confusion**: a symptom in `app/` whose root is a missing/renamed `api/` field is a **contract** bug, not an app bug — fix the api once, not every template.
+- **Missing `GRANT`**: an app-tier read returning empty/500 for a *new* table is usually the `wittkensis`→`glintstone` grant, not app code — that's a **migration** fix.
+- **NULLs are expected** (coverage is partial): a "missing data" symptom may be correct behavior (no annotation exists), not a bug. Confirm the row should exist before classifying.
+- **Attribution**: a "wrong/overwritten annotation" symptom may be a structural-attribution violation (silently overwrote instead of new `annotation_run_id` run) — a data-model domain bug.
+
+## Return (exactly this shape)
+```
+INVARIANT: <the rule violated>
+CLASSIFICATION: api-only | app-only | shared:contract | shared:token | shared:migration | shared:domain
+ROOT: <file:line where the cause lives, by tier>
+BLAST RADIUS: <tier(s) that actually exhibit it> / <call-site count per tier>
+FIX TIER: <where to fix + why that tier, not lower/higher>
+CONTRACT/GRANT IMPACT: <api fields or table grants that must move together / none>
+CODIFY: <gs-audit dimension, pytest contract assertion, GRANT check, gs-expert to tighten, or "n/a">
+OWNING GS-EXPERT: <gs-expert-data-model | -ui | -integrations | -assyriology | -deployment>
+EVIDENCE: <2–4 file:line cites backing the above>
+```
+TERMINATION: deliver the block above. You are read-only — propose the tier, never apply it; the orchestrator or a swarm-worker (briefed with the owning gs-expert) does the fix.
+
+## Related
+- `gs-swarm` — dispatches this in its triage phase (one per symptom, parallel)
+- `canary-in-the-coalmine` — generic: the per-bug class-closing loop this feeds (this skill names the tier; that one closes the class)
+- `gs-orient-project` — the two-tier architecture + non-negotiables this scout reasons against

--- a/.claude/skills/gs-orient-project/SKILL.md
+++ b/.claude/skills/gs-orient-project/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   audience: [claude, engineers]
   owners: [eric]
   related_issues: ["#60"]
-  related_skills: [gs-expert-integrations, gs-expert-data-model, gs-expert-ui, gs-expert-deployment, gs-expert-assyriology, gs-scout-integrations, gs-curator-artifacts, gs-curator-docs, gs-audit-hardening]
+  related_skills: [gs-expert-integrations, gs-expert-data-model, gs-expert-ui, gs-expert-deployment, gs-expert-assyriology, gs-scout-integrations, gs-curator-artifacts, gs-curator-docs, gs-audit-hardening, gs-swarm, gs-canary]
   supersedes: null
   superseded_by: null
   triggers: [glintstone, cuneiform, tablet, p-number, P-number, ATF, scholar, "what is", "where is", "where does", "how does", project overview]
@@ -94,6 +94,8 @@ Coverage gap: ~2% of artifacts lemmatized, ~35% have ATF, ~12% have translations
 | commit, push, ship, PR, release | **gs-curator-docs** |
 | audit, harden, "security review", "deployment review", "performance audit", "run the audit" | **gs-audit-hardening** |
 | "frontend audit", "design audit", "css audit", "design system", "frontend entropy", "clean up the css" | **gs-audit-frontend** |
+| "swarm", "build feature", "parallel build", "fan out", "run a swarm", multi-part build/audit | **gs-swarm** |
+| "canary", "blast radius", "which tier", "api or app", "this smells systemic", triage a bug | **gs-canary** |
 
 ## Non-negotiables
 

--- a/.claude/skills/gs-swarm/SKILL.md
+++ b/.claude/skills/gs-swarm/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: gs-swarm
+description: Glintstone-tuned parallel build/maintenance swarm. Wraps the generic `swarm` lifecycle but pins the right gs-* expert at each phase — gs-canary for triage/blast-radius, the gs-expert-* domain skills for fan-out, gs-expert-deployment + gs-curator-docs for the validate/ship gate — and enforces Glintstone's invariants (two-tier api/app split, migrations-as-wittkensis, one-deploy-at-a-time, source attribution). Use for any multi-part build, feature, or audit on Glintstone that splits into independent units. Triggers — glintstone swarm, glintstone build, build feature, parallel build, fan out, run audit, bug-bash.
+metadata:
+  question: "How do I run a parallel multi-agent build/audit on Glintstone with the right gs-* expert locked into each phase and Glintstone's invariants enforced?"
+  created: 2026-06-25
+  modified: 2026-06-25
+  context: "Back-ported from fleet--swarm (the *.ericwittke.com fleet swarm) during backlog #29 Phase 3. The fleet version pins fleet--canary-scout / engineer / deploy-verifier per phase and guards kw-system. This Glintstone version pins the gs-* family and guards Glintstone's reality instead: the two-tier api↔app HTTP boundary, migrations run as wittkensis, serialized deploys (one VPS release at a time), and structural source attribution."
+  status: active
+  audience: [claude, engineers]
+  owners: [eric]
+  related_issues: ["#29"]
+  related_skills: [gs-canary, gs-expert-deployment, gs-expert-data-model, gs-expert-integrations, gs-expert-ui, gs-expert-assyriology, gs-curator-docs, gs-orient-project]
+  supersedes: null
+  superseded_by: null
+  triggers: [swarm, "glintstone swarm", "glintstone build", "build feature", "parallel build", "fan out", "run audit", "bug-bash", orchestrate, decompose]
+---
+
+# Glintstone Swarm
+
+## Invocation
+Triggers: glintstone swarm, glintstone build, build feature, parallel build, fan out, run audit, bug-bash
+
+The generic `swarm` lifecycle (decompose → worktrees → fan out → integrate → validate) with the **right gs-* expert locked into each phase** and Glintstone's invariants enforced. Use this — not bare `swarm` — whenever a Glintstone build/fix/audit splits into ≥2 independent units. Run the generic `swarm` skill for the orchestration mechanics; this skill only overrides *which gs-* skill governs which phase* and the Glintstone guardrails.
+
+## Phase → skill/agent map (the whole point)
+
+| Phase | Skill / agent | Why |
+|-------|---------------|-----|
+| **Triage / blast-radius** | `gs-canary` (read-only — run one per distinct symptom) | Decide **api-only vs app-only vs shared** (the api↔app contract, the token CSS, a migration, a gs-expert domain) *before* fixing, so a symptom isn't patched on both tiers or in the wrong tier. Skip for a single obviously-local change. |
+| **Decompose** | `Plan` agent + the routing map below | Cut the work along the two-tier seam and by file ownership; every unit's `owns` set disjoint. |
+| **Build / fan-out** | `swarm-worker` (`run_in_background`, `isolation:"worktree"`), each briefed with its gs-expert domain | Each worker owns one slice the Glintstone way (see routing). Migration units run as `wittkensis` + `GRANT` to `glintstone`. |
+| **Validate** | `gs-expert-deployment` (CI/pipeline gate) + `gs-curator-docs` (commit/push freshness) | Two-tier: pytest/ruff/mypy green, then **exercise** the feature against a running api+web pair. Deploys are serialized — one VPS release at a time. |
+
+## Routing — which gs-expert governs each unit
+
+Brief each `swarm-worker` with the gs-expert skill its slice lives under (scoped memory per worker, not a shared pile):
+
+| Unit touches | Worker loads | Owns (typical) |
+|---|---|---|
+| New connector / source / ETL | `gs-expert-integrations` | `ingestion/connectors/*.py`, `ingestion/base.py` |
+| Schema, migration, repository, query, lexical | `gs-expert-data-model` | `source-data/migrations/NNN_*.sql`, `core/`, `api/repositories/` |
+| ATF, lemma, sign, glossary, morphology | `gs-expert-assyriology` | the linguistics slice of the above |
+| CSS, BEM, templates, accessibility | `gs-expert-ui` | `app/templates/`, `app/static/` |
+| Deploy, pipeline, supervisor, env | `gs-expert-deployment` | `ops/deploy/`, `.github/workflows/` |
+| Commit / push / PR | `gs-curator-docs` | n/a — the ship gate |
+
+## Flow
+1. **Triage.** If the change spans the api↔app seam or smells systemic, fan out `gs-canary` (one per distinct symptom, parallel); read each CLASSIFICATION/FIX-TIER. **Fix shared roots once** — a contract change in `api/` that `app/` consumes, a token in the CSS, a base migration — before per-unit work.
+2. **Decompose** (`Plan` agent) along the **two-tier seam first**, then by file ownership. The api↔app boundary is a natural cut line: an `api/` unit and the `app/` unit that consumes it are usually *separate* units in *separate waves* (app depends on the new API endpoint). **HARD CHECK:** every `owns` set disjoint — no two concurrent units write the same file.
+3. **Group into waves** by dependency depth. API/contract/migration units are almost always **wave 1** (the app tier and UI depend on them).
+4. **Fan out** `swarm-worker`, one unit each, background worktrees, each briefed with its gs-expert domain + numbered deliverables. **Migration units:** run migrations as `wittkensis`; after any new table/sequence, `GRANT` to `glintstone` (or the app tier can't read it). Honor the psycopg rollback trap (`ON CONFLICT`/`NOT EXISTS`, not try/except).
+5. **Integrate** in dependency order (orchestrator owns merges; workers never merge). Glintstone is a single repo — one commit history; commit per logical unit, not batched blindly.
+6. **Validate & ship.** `gs-expert-deployment` gate: pytest + ruff + mypy green, then **exercise the feature against a running api+web pair** (the two-tier contract only proves out live — "it compiled" misses a 500 from a missing `GRANT` or a contract drift). Then `gs-curator-docs` for the commit/push freshness check. **Deploys are serialized:** one VPS release at a time — never two `deploy.yml` runs racing the symlink swap. Push to `main` only with CI green; never `--no-verify`.
+
+> **Pipeline, not a toss:** the two-tier seam is the spine of a Glintstone swarm. Cut along it, ship the API tier first, and the app tier has a real contract to build against instead of guessing.
+
+## Guardrails (inherited from Glintstone CLAUDE.md / gs-orient-project — non-negotiable)
+- **Two-tier boundary**: `app/` never touches the DB — it calls `api/` over HTTP (httpx). No unit may smuggle a DB call into the web tier.
+- **Migrations as `wittkensis`**; new tables/sequences need an explicit `GRANT` to `glintstone`.
+- **psycopg rollback trap**: `conn.rollback()` undoes ALL uncommitted work — use `ON CONFLICT`/`NOT EXISTS`.
+- **Source attribution is structural**: annotation rows carry `annotation_run_id`; never silently overwrite — new run.
+- **Competing interpretations are a feature**: don't dedupe on disagreement.
+- **Serialized deploy**: one VPS release at a time; CI green before `main`; never `--no-verify`; route every deploy through `gs-expert-deployment`.
+- **Verify by exercising** a live api+web pair, not by reading code.
+
+TERMINATION: done when every in-scope unit meets its done-criterion, shared roots (contract/token/migration) are fixed once at the right tier, the api+web pair has been exercised green (pytest/ruff/mypy + a live run), and the change is committed (pushed only if the user authorized a deploy, serialized) — or the blocked units are reported with reasons.
+
+## Related
+- `swarm` — generic: the orchestration mechanics this wraps (decompose, worktrees, integrate, validate gate)
+- `gs-canary` — the triage-phase blast-radius scout this dispatches
+- `gs-expert-deployment` — the validate/ship gate; owns deploy serialization
+- `gs-curator-docs` — commit/push freshness gate
+- `canary-in-the-coalmine` — generic per-bug class-closing loop (gs-canary is the Glintstone-tiered front of it)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ Open `gs-orient-project/SKILL.md` for the routing map. That skill auto-loads at 
 | `gs-curator-docs` | Before any `git commit` or `git push` (freshness check) |
 | `gs-audit-hardening` | Hardening pass, audit, "review the deployment", "run the audit" |
 | `gs-audit-frontend` | Frontend/design audit, "design system", "css audit", "clean up the frontend", "frontend entropy" |
+| `gs-swarm` | Parallel multi-part build/feature/audit — "swarm", "fan out", "build feature", "run audit" (Glintstone-tuned: two-tier decompose, serialized deploy) |
+| `gs-canary` | Blast-radius triage for a bug/change — "which tier", "api or app", "blast radius", "this smells systemic" (read-only recon) |
 | `giddyup` | Backlog triage — "what's next?", "what should I work on?", "prioritize", "sequence the backlog" |
 
 ## Tech stack (quick)


### PR DESCRIPTION
Back-ports the fleet's swarm + canary-scout tooling into Glintstone's `gs-*` family — adapted to Glintstone's reality, not generic copies. Closes #29 (HARNESS-PORT Phase 3).

## What
- **`gs-swarm`** — Glintstone-tuned parallel build/audit swarm. Wraps the generic `swarm` lifecycle but pins a gs-expert per phase (`gs-canary` for triage, the `gs-expert-*` domains for fan-out, `gs-expert-deployment` + `gs-curator-docs` for validate/ship) and enforces Glintstone invariants: **two-tier api/app decompose** (cut along the seam, ship the API tier first), **migrations-as-`wittkensis`** (+ `GRANT` to `glintstone`), **serialized one-deploy-at-a-time**, structural source attribution.
- **`gs-canary`** — read-only blast-radius scout. Classifies a bug as **api-only / app-only / shared** (contract drift · token CSS · migration · gs-expert domain) and names the cheapest correct tier to fix. The Glintstone-tiered front of `canary-in-the-coalmine`.

## Adaptation vs the fleet originals
| Fleet | Glintstone |
|---|---|
| `fleet--swarm` pins engineer/deploy-verifier, guards kw-system/Tailwind | `gs-swarm` pins gs-expert-*, guards two-tier seam + serialized deploy + wittkensis migrations |
| `fleet--canary-scout` classifies app-local / kw-system base / template across cloned apps | `gs-canary` classifies api-only / app-only / shared(contract·token·migration·domain) across the two tiers |

## Registered
- `gs-orient-project` routing map + `related_skills`
- `CLAUDE.md` "where to look first" table

## Gate
- Frontmatter valid YAML for both new files.
- `gs-curator-docs` doc-header check clean for both (pre-existing failures in unrelated files untouched).
- Docs/skills only — no app behavior, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaVPgcKSmgDDwvBnKU4Je1